### PR TITLE
Add activity log and weekly review endpoint

### DIFF
--- a/app/activity_log.py
+++ b/app/activity_log.py
@@ -1,0 +1,43 @@
+"""Activity logging for weekly reviews and audit trails.
+
+Usage from any router:
+    from ..activity_log import log_activity
+    log_activity(db, actor_id="emp-abc", action="created", entity_type="invoice",
+                 entity_id="inv-123", project_id="JBHL21")
+"""
+
+import json
+import logging
+
+from .utils import generate_id
+
+logger = logging.getLogger(__name__)
+
+
+def log_activity(
+    db,
+    *,
+    action: str,
+    entity_type: str,
+    entity_id: str,
+    project_id: str | None = None,
+    actor_id: str | None = None,
+    metadata: dict | None = None,
+):
+    """Insert an activity log entry. Best-effort — never raises."""
+    try:
+        db.execute(
+            "INSERT INTO activity_log (id, actor_id, action, entity_type, entity_id, project_id, metadata) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (
+                generate_id("act-"),
+                actor_id,
+                action,
+                entity_type,
+                entity_id,
+                project_id,
+                json.dumps(metadata) if metadata else None,
+            ),
+        )
+    except Exception:
+        logger.warning("Failed to log activity: %s %s %s", action, entity_type, entity_id, exc_info=True)

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
-from .routers import auth, clients, company, contracts, employees, flows, invoices, projects, proposals, tasks, uploads
+from .routers import auth, clients, company, contracts, employees, flows, invoices, projects, proposals, reports, tasks, uploads
 
 _log_file = Path(__file__).resolve().parent.parent / "conductor.log"
 logging.basicConfig(
@@ -60,6 +60,7 @@ app.include_router(proposals.router, prefix="/api/proposals", tags=["proposals"]
 app.include_router(invoices.router, prefix="/api/invoices", tags=["invoices"])
 app.include_router(employees.router, prefix="/api/employees", tags=["employees"])
 app.include_router(tasks.router, prefix="/api", tags=["tasks"])
+app.include_router(reports.router, prefix="/api/reports", tags=["reports"])
 app.include_router(flows.router, prefix="/api/flows", tags=["flows"])
 app.include_router(uploads.router, prefix="/api/uploads", tags=["uploads"])
 

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from ..database import get_db
+
+router = APIRouter()
+
+
+@router.get("/weekly-activity")
+def get_weekly_activity(
+    weeks_ago: int = Query(0, ge=0, le=52),
+    db=Depends(get_db),
+):
+    """Return structured weekly activity data for team review.
+
+    weeks_ago=0 means current week (Mon-Sun).
+    weeks_ago=1 means last week, etc.
+    """
+    # Calculate week boundaries (Monday to Sunday)
+    today = datetime.now().date()
+    days_since_monday = today.weekday()  # 0=Mon, 6=Sun
+    this_monday = today - timedelta(days=days_since_monday)
+    week_start = this_monday - timedelta(weeks=weeks_ago)
+    week_end = week_start + timedelta(days=7)
+
+    start_str = week_start.isoformat()
+    end_str = week_end.isoformat()
+
+    # --- Activity log entries for this week ---
+    activity_rows = db.execute(
+        "SELECT a.*, "
+        "COALESCE(e.first_name || ' ' || e.last_name, 'System') AS actor_name, "
+        "p.name AS project_name "
+        "FROM activity_log a "
+        "LEFT JOIN employees e ON a.actor_id = e.id "
+        "LEFT JOIN projects p ON a.project_id = p.id "
+        "WHERE a.created_at >= %s AND a.created_at < %s "
+        "ORDER BY a.created_at DESC",
+        (start_str, end_str),
+    ).fetchall()
+    activity = [dict(r) for r in activity_rows]
+
+    # --- Group activity by employee ---
+    by_employee = {}
+    for row in activity:
+        name = row["actor_name"]
+        if name not in by_employee:
+            by_employee[name] = []
+        by_employee[name].append({
+            "action": row["action"],
+            "entity_type": row["entity_type"],
+            "entity_id": row["entity_id"],
+            "project_name": row["project_name"],
+            "metadata": row["metadata"],
+            "created_at": row["created_at"],
+        })
+
+    # --- Active projects ---
+    active_rows = db.execute(
+        "SELECT p.id, p.name, p.status, p.job_code, p.project_number, "
+        "c.name AS client_name, c.company AS client_company "
+        "FROM projects p "
+        "LEFT JOIN clients c ON p.client_id = c.id "
+        "WHERE p.deleted_at IS NULL AND p.status NOT IN ('complete', 'paid') "
+        "ORDER BY p.created_at DESC"
+    ).fetchall()
+    active_projects = [dict(r) for r in active_rows]
+
+    # --- Summary stats from activity log ---
+    stats_row = db.execute(
+        "SELECT "
+        "COUNT(*) FILTER (WHERE entity_type = 'proposal' AND action = 'created') AS proposals_created, "
+        "COUNT(*) FILTER (WHERE entity_type = 'proposal' AND action = 'sent') AS proposals_sent, "
+        "COUNT(*) FILTER (WHERE entity_type = 'invoice' AND action = 'created') AS invoices_created, "
+        "COUNT(*) FILTER (WHERE entity_type = 'invoice' AND action = 'sent') AS invoices_sent, "
+        "COUNT(*) FILTER (WHERE entity_type = 'invoice' AND action = 'paid') AS invoices_paid, "
+        "COUNT(*) FILTER (WHERE entity_type = 'project_task' AND action = 'completed') AS tasks_completed, "
+        "COUNT(*) FILTER (WHERE entity_type = 'project_task' AND action = 'created') AS tasks_created, "
+        "COUNT(*) FILTER (WHERE entity_type IN ('project_note', 'task_note') AND action = 'created') AS notes_written, "
+        "COUNT(*) FILTER (WHERE entity_type = 'project' AND action = 'created') AS projects_created, "
+        "COUNT(*) FILTER (WHERE entity_type = 'contract' AND action = 'created') AS contracts_created "
+        "FROM activity_log "
+        "WHERE created_at >= %s AND created_at < %s",
+        (start_str, end_str),
+    ).fetchone()
+    summary = dict(stats_row) if stats_row else {}
+
+    return {
+        "week_start": start_str,
+        "week_end": end_str,
+        "weeks_ago": weeks_ago,
+        "summary": summary,
+        "active_projects": active_projects,
+        "activity_by_employee": by_employee,
+        "recent_activity": activity,
+    }

--- a/db/migrations/017_add_activity_log.sql
+++ b/db/migrations/017_add_activity_log.sql
@@ -1,0 +1,18 @@
+-- Activity log for tracking who did what
+-- Used by weekly review reports
+
+CREATE TABLE IF NOT EXISTS activity_log (
+    id TEXT PRIMARY KEY,
+    actor_id TEXT REFERENCES employees(id),    -- who performed the action (NULL if unknown)
+    action TEXT NOT NULL,                       -- 'created', 'sent', 'completed', 'signed', 'paid', 'deleted', 'promoted'
+    entity_type TEXT NOT NULL,                  -- 'invoice', 'proposal', 'project', 'project_task', 'contract', 'project_note', 'task_note'
+    entity_id TEXT NOT NULL,                    -- ID of the entity acted upon
+    project_id TEXT REFERENCES projects(id),    -- denormalized for fast weekly queries
+    metadata JSONB,                             -- optional context (e.g., {"old_status": "draft", "new_status": "sent"})
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_actor ON activity_log(actor_id);
+CREATE INDEX IF NOT EXISTS idx_activity_log_project ON activity_log(project_id);
+CREATE INDEX IF NOT EXISTS idx_activity_log_entity_type ON activity_log(entity_type);
+CREATE INDEX IF NOT EXISTS idx_activity_log_created_at ON activity_log(created_at);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -337,6 +337,27 @@ CREATE TABLE project_notes (
 
 CREATE INDEX idx_project_notes_project ON project_notes(project_id);
 
+
+-- ============================================================================
+-- ACTIVITY LOG
+-- Tracks who did what for weekly reviews and audit trails
+-- ============================================================================
+CREATE TABLE activity_log (
+    id TEXT PRIMARY KEY,
+    actor_id TEXT REFERENCES employees(id),    -- who performed the action (NULL if unknown)
+    action TEXT NOT NULL,                       -- 'created', 'sent', 'completed', 'signed', 'paid', 'deleted', 'promoted'
+    entity_type TEXT NOT NULL,                  -- 'invoice', 'proposal', 'project', 'project_task', 'contract', 'project_note', 'task_note'
+    entity_id TEXT NOT NULL,                    -- ID of the entity acted upon
+    project_id TEXT REFERENCES projects(id),    -- denormalized for fast weekly queries
+    metadata JSONB,                             -- optional context (e.g., {"old_status": "draft", "new_status": "sent"})
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_activity_log_actor ON activity_log(actor_id);
+CREATE INDEX idx_activity_log_project ON activity_log(project_id);
+CREATE INDEX idx_activity_log_entity_type ON activity_log(entity_type);
+CREATE INDEX idx_activity_log_created_at ON activity_log(created_at);
+
 -- ============================================================================
 -- VIEWS
 -- Computed totals and useful joins


### PR DESCRIPTION
## Summary
- New `activity_log` table to track who did what (actor, action, entity, project, timestamp, metadata)
- Best-effort `log_activity()` helper — never crashes the parent operation
- 27 log points across 5 routers: invoices, proposals, projects, tasks, contracts
- New `GET /api/reports/weekly-activity` endpoint returns structured weekly data grouped by employee

## Context
Foundation for a weekly team review feature. This is Phase 1 (data collection + query endpoint). Phase 2 will be a PAI skill that consumes this endpoint to generate a shareable Google Doc.

## What's logged
- **Invoices:** created, sent, paid, finalized, sheet generated, deleted
- **Proposals:** created, sent, promoted to contract, deleted
- **Projects:** created, deleted, standalone invoice added, note written
- **Tasks:** created, completed, status changed, note written
- **Contracts:** created, deleted, invoice from contract created

## Test plan
- [x] Migration runs cleanly (IF NOT EXISTS guards)
- [x] All 8 passing tests still pass (1 pre-existing failure on master unrelated)
- [x] No existing API responses or status codes changed
- [x] `log_activity` wrapped in try/except — logging failures don't affect business operations
- [ ] Deploy and verify activity_log rows appear after real usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)