### PR TITLE
Add company wiki with markdown and image support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from .routers import activity_log, auth, clients, company, contacts, contracts, employees, flows, invoices, projects, proposals, raindrop_analytics, tasks, time_entries, uploads, updates
+from .routers import activity_log, auth, clients, company, contacts, contracts, employees, flows, invoices, projects, proposals, raindrop_analytics, tasks, time_entries, uploads, updates, wiki
 
 _log_file = Path(__file__).resolve().parent.parent / "conductor.log"
 logging.basicConfig(
@@ -82,6 +82,7 @@ app.include_router(uploads.router, prefix="/api/uploads", tags=["uploads"])
 app.include_router(updates.router, prefix="/api/updates", tags=["updates"])
 app.include_router(activity_log.router, prefix="/api/activity-log", tags=["activity-log"])
 app.include_router(raindrop_analytics.router, prefix="/api/raindrop", tags=["raindrop"])
+app.include_router(wiki.router, prefix="/api/wiki", tags=["wiki"])
 
 # --- Static files (Vue SPA) ---
 static_root = Path(__file__).resolve().parent.parent

--- a/app/models/wiki_note.py
+++ b/app/models/wiki_note.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class WikiNoteCreate(BaseModel):
+    title: str
+    content: str = ""
+    category: str = "General"
+    created_by: str | None = None
+
+
+class WikiNoteUpdate(BaseModel):
+    title: str | None = None
+    content: str | None = None
+    category: str | None = None
+    updated_by: str | None = None
+
+
+class WikiNoteResponse(BaseModel):
+    id: str
+    title: str
+    content: str
+    category: str
+    created_by: str | None = None
+    updated_by: str | None = None
+    created_by_name: str | None = None
+    updated_by_name: str | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None

--- a/app/routers/wiki.py
+++ b/app/routers/wiki.py
@@ -1,0 +1,122 @@
+import re
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..database import get_db
+from ..models.wiki_note import WikiNoteCreate, WikiNoteResponse, WikiNoteUpdate
+from ..utils import generate_id
+
+_root = Path(__file__).resolve().parent.parent.parent
+_IMAGE_RE = re.compile(r'!\[.*?\]\((/uploads/images/[^)]+)\)')
+
+router = APIRouter()
+
+_SELECT = (
+    "SELECT w.id, w.title, w.content, w.category, "
+    "w.created_by, w.updated_by, w.created_at, w.updated_at, "
+    "e1.first_name || ' ' || e1.last_name AS created_by_name, "
+    "e2.first_name || ' ' || e2.last_name AS updated_by_name "
+    "FROM wiki_notes w "
+    "LEFT JOIN employees e1 ON w.created_by = e1.id "
+    "LEFT JOIN employees e2 ON w.updated_by = e2.id "
+    "WHERE w.deleted_at IS NULL "
+)
+
+
+@router.get("/categories")
+def list_categories(db=Depends(get_db)):
+    rows = db.execute(
+        "SELECT DISTINCT category FROM wiki_notes "
+        "WHERE deleted_at IS NULL ORDER BY category"
+    ).fetchall()
+    return [r["category"] for r in rows]
+
+
+@router.get("", response_model=list[WikiNoteResponse])
+def list_notes(
+    q: str | None = Query(None, description="Search title and content"),
+    category: str | None = Query(None, description="Filter by category"),
+    db=Depends(get_db),
+):
+    sql = _SELECT
+    params: list = []
+
+    if q:
+        like = f"%{q}%"
+        sql += "AND (w.title ILIKE %s OR w.content ILIKE %s) "
+        params.extend([like, like])
+
+    if category:
+        sql += "AND w.category = %s "
+        params.append(category)
+
+    sql += "ORDER BY w.updated_at DESC"
+    rows = db.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+@router.get("/{note_id}", response_model=WikiNoteResponse)
+def get_note(note_id: str, db=Depends(get_db)):
+    row = db.execute(_SELECT + "AND w.id = %s", (note_id,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Note not found")
+    return dict(row)
+
+
+@router.post("", response_model=WikiNoteResponse, status_code=201)
+def create_note(data: WikiNoteCreate, db=Depends(get_db)):
+    note_id = generate_id("wiki-")
+    now = datetime.now().isoformat()
+    db.execute(
+        "INSERT INTO wiki_notes (id, title, content, category, created_by, updated_by, created_at, updated_at) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+        (note_id, data.title, data.content, data.category, data.created_by, data.created_by, now, now),
+    )
+    db.commit()
+
+    row = db.execute(_SELECT + "AND w.id = %s", (note_id,)).fetchone()
+    return dict(row)
+
+
+@router.patch("/{note_id}", response_model=WikiNoteResponse)
+def update_note(note_id: str, data: WikiNoteUpdate, db=Depends(get_db)):
+    existing = db.execute(
+        "SELECT id FROM wiki_notes WHERE id = %s AND deleted_at IS NULL", (note_id,)
+    ).fetchone()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Note not found")
+
+    updates = {k: v for k, v in data.model_dump().items() if v is not None}
+    if not updates:
+        row = db.execute(_SELECT + "AND w.id = %s", (note_id,)).fetchone()
+        return dict(row)
+
+    updates["updated_at"] = datetime.now().isoformat()
+    set_clause = ", ".join(f"{k} = %s" for k in updates)
+    values = list(updates.values()) + [note_id]
+    db.execute(f"UPDATE wiki_notes SET {set_clause} WHERE id = %s", values)
+    db.commit()
+
+    row = db.execute(_SELECT + "AND w.id = %s", (note_id,)).fetchone()
+    return dict(row)
+
+
+@router.delete("/{note_id}")
+def delete_note(note_id: str, db=Depends(get_db)):
+    existing = db.execute(
+        "SELECT id, content FROM wiki_notes WHERE id = %s AND deleted_at IS NULL", (note_id,)
+    ).fetchone()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Note not found")
+
+    # Delete attached images from disk
+    for match in _IMAGE_RE.finditer(existing["content"] or ""):
+        img_path = _root / match.group(1).lstrip("/")
+        img_path.unlink(missing_ok=True)
+
+    now = datetime.now().isoformat()
+    db.execute("UPDATE wiki_notes SET deleted_at = %s WHERE id = %s", (now, note_id))
+    db.commit()
+    return {"success": True}

--- a/app/routers/wiki.py
+++ b/app/routers/wiki.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import datetime
 from pathlib import Path
@@ -7,6 +8,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from ..database import get_db
 from ..models.wiki_note import WikiNoteCreate, WikiNoteResponse, WikiNoteUpdate
 from ..utils import generate_id
+
+logger = logging.getLogger(__name__)
 
 _root = Path(__file__).resolve().parent.parent.parent
 _IMAGE_RE = re.compile(r'!\[.*?\]\((/uploads/images/[^)]+)\)')
@@ -111,12 +114,16 @@ def delete_note(note_id: str, db=Depends(get_db)):
     if not existing:
         raise HTTPException(status_code=404, detail="Note not found")
 
-    # Delete attached images from disk
-    for match in _IMAGE_RE.finditer(existing["content"] or ""):
-        img_path = _root / match.group(1).lstrip("/")
-        img_path.unlink(missing_ok=True)
-
     now = datetime.now().isoformat()
     db.execute("UPDATE wiki_notes SET deleted_at = %s WHERE id = %s", (now, note_id))
     db.commit()
+
+    # Best-effort image cleanup after commit
+    for match in _IMAGE_RE.finditer(existing["content"] or ""):
+        img_path = _root / match.group(1).lstrip("/")
+        try:
+            img_path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning("Failed to delete wiki image %s for note %s: %s", img_path, note_id, e)
+
     return {"success": True}

--- a/db/migrations/027_add_wiki_notes.sql
+++ b/db/migrations/027_add_wiki_notes.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS wiki_notes (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    category TEXT NOT NULL DEFAULT 'General',
+    created_by TEXT REFERENCES employees(id),
+    updated_by TEXT REFERENCES employees(id),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_notes_category ON wiki_notes(category);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@primevue/themes": "^4.5.4",
         "chart.js": "^4.5.1",
+        "dompurify": "^3.3.3",
+        "marked": "^17.0.5",
         "primeicons": "^7.0.0",
         "primevue": "^4.5.4",
         "vue": "^3.5.25",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^24.10.1",
         "@vitejs/plugin-vue": "^6.0.2",
         "@vue/tsconfig": "^0.8.1",
@@ -989,6 +992,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1005,6 +1018,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.4",
@@ -1359,6 +1379,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1476,6 +1505,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/muggle-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,12 +12,15 @@
   "dependencies": {
     "@primevue/themes": "^4.5.4",
     "chart.js": "^4.5.1",
+    "dompurify": "^3.3.3",
+    "marked": "^17.0.5",
     "primeicons": "^7.0.0",
     "primevue": "^4.5.4",
     "vue": "^3.5.25",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^24.10.1",
     "@vitejs/plugin-vue": "^6.0.2",
     "@vue/tsconfig": "^0.8.1",

--- a/frontend/src/api/wiki.ts
+++ b/frontend/src/api/wiki.ts
@@ -1,0 +1,44 @@
+import type { WikiNote } from '../types'
+import { apiFetch } from './client'
+
+export function getWikiNotes(q?: string, category?: string): Promise<WikiNote[]> {
+  const params = new URLSearchParams()
+  if (q) params.set('q', q)
+  if (category) params.set('category', category)
+  const qs = params.toString()
+  return apiFetch(`/wiki${qs ? '?' + qs : ''}`)
+}
+
+export function getWikiCategories(): Promise<string[]> {
+  return apiFetch('/wiki/categories')
+}
+
+export function getWikiNote(id: string): Promise<WikiNote> {
+  return apiFetch(`/wiki/${id}`)
+}
+
+export function createWikiNote(data: {
+  title: string
+  content?: string
+  category?: string
+  created_by?: string | null
+}): Promise<WikiNote> {
+  return apiFetch('/wiki', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export function updateWikiNote(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<WikiNote> {
+  return apiFetch(`/wiki/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}
+
+export function deleteWikiNote(id: string): Promise<{ success: boolean }> {
+  return apiFetch(`/wiki/${id}`, { method: 'DELETE' })
+}

--- a/frontend/src/components/MarkdownRenderer.vue
+++ b/frontend/src/components/MarkdownRenderer.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+const props = defineProps<{
+  content: string
+  noteIndex?: Map<string, string>  // title (lowercase) -> id
+}>()
+
+const router = useRouter()
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+})
+
+function processWikiLinks(text: string): string {
+  // Replace [[Page Title]] with clickable links
+  return text.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
+    const trimmed = title.trim()
+    const noteId = props.noteIndex?.get(trimmed.toLowerCase())
+    if (noteId) {
+      return `<a href="/wiki/${noteId}" class="wiki-link">${trimmed}</a>`
+    }
+    return `<span class="wiki-link-missing">${trimmed}</span>`
+  })
+}
+
+const rendered = computed(() => {
+  if (!props.content) return ''
+  const withLinks = processWikiLinks(props.content)
+  const html = marked.parse(withLinks) as string
+  return DOMPurify.sanitize(html, { ADD_ATTR: ['class'] })
+})
+
+function handleClick(e: MouseEvent) {
+  const target = e.target as HTMLElement
+  const link = target.closest('a.wiki-link') as HTMLAnchorElement | null
+  if (link) {
+    e.preventDefault()
+    const href = link.getAttribute('href')
+    if (href) router.push(href)
+  }
+}
+</script>
+
+<template>
+  <div class="markdown-body" v-html="rendered" @click="handleClick" />
+</template>
+
+<style scoped>
+.markdown-body {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--p-text-color);
+  word-wrap: break-word;
+}
+
+.markdown-body :deep(h1) {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--p-content-border-color);
+}
+
+.markdown-body :deep(h2) {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+
+.markdown-body :deep(h3) {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.375rem;
+}
+
+.markdown-body :deep(p) {
+  margin: 0.5rem 0;
+}
+
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+
+.markdown-body :deep(li) {
+  margin: 0.25rem 0;
+}
+
+.markdown-body :deep(code) {
+  background: var(--p-surface-100);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  font-family: monospace;
+}
+
+:root.p-dark .markdown-body :deep(code) {
+  background: var(--p-surface-700);
+}
+
+.markdown-body :deep(pre) {
+  background: var(--p-surface-100);
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+:root.p-dark .markdown-body :deep(pre) {
+  background: var(--p-surface-800);
+}
+
+.markdown-body :deep(pre code) {
+  background: none;
+  padding: 0;
+}
+
+.markdown-body :deep(blockquote) {
+  border-left: 3px solid var(--p-primary-color);
+  padding-left: 0.75rem;
+  margin: 0.5rem 0;
+  color: var(--p-text-muted-color);
+}
+
+.markdown-body :deep(table) {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0.5rem 0;
+}
+
+.markdown-body :deep(th),
+.markdown-body :deep(td) {
+  border: 1px solid var(--p-content-border-color);
+  padding: 0.375rem 0.75rem;
+  text-align: left;
+  font-size: 0.8125rem;
+}
+
+.markdown-body :deep(th) {
+  background: color-mix(in srgb, var(--p-content-background) 90%, var(--p-text-muted-color) 10%);
+  font-weight: 600;
+  color: var(--p-text-color);
+}
+
+.markdown-body :deep(.wiki-link) {
+  color: var(--p-primary-color);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--p-primary-color);
+  cursor: pointer;
+}
+
+.markdown-body :deep(.wiki-link:hover) {
+  border-bottom-style: solid;
+}
+
+.markdown-body :deep(.wiki-link-missing) {
+  color: var(--p-red-500);
+  border-bottom: 1px dashed var(--p-red-400);
+}
+
+.markdown-body :deep(a) {
+  color: var(--p-primary-color);
+  text-decoration: none;
+}
+
+.markdown-body :deep(a:hover) {
+  text-decoration: underline;
+}
+
+.markdown-body :deep(img) {
+  max-width: 100%;
+  border-radius: 0.375rem;
+  margin: 0.5rem 0;
+}
+
+.markdown-body :deep(hr) {
+  border: none;
+  border-top: 1px solid var(--p-content-border-color);
+  margin: 1rem 0;
+}
+</style>

--- a/frontend/src/components/MarkdownRenderer.vue
+++ b/frontend/src/components/MarkdownRenderer.vue
@@ -11,27 +11,27 @@ const props = defineProps<{
 
 const router = useRouter()
 
-marked.setOptions({
-  breaks: true,
-  gfm: true,
-})
+const md = new marked.Marked({ breaks: true, gfm: true })
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
 
 function processWikiLinks(text: string): string {
-  // Replace [[Page Title]] with clickable links
   return text.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
     const trimmed = title.trim()
     const noteId = props.noteIndex?.get(trimmed.toLowerCase())
     if (noteId) {
-      return `<a href="/wiki/${noteId}" class="wiki-link">${trimmed}</a>`
+      return `<a href="/wiki/${escapeHtml(noteId)}" class="wiki-link">${escapeHtml(trimmed)}</a>`
     }
-    return `<span class="wiki-link-missing">${trimmed}</span>`
+    return `<span class="wiki-link-missing">${escapeHtml(trimmed)}</span>`
   })
 }
 
 const rendered = computed(() => {
   if (!props.content) return ''
   const withLinks = processWikiLinks(props.content)
-  const html = marked.parse(withLinks) as string
+  const html = md.parse(withLinks) as string
   return DOMPurify.sanitize(html, { ADD_ATTR: ['class'] })
 })
 

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -25,6 +25,7 @@ const navItems = [
   { label: 'Clients', icon: 'pi pi-users', route: '/clients' },
   { label: 'Financial', icon: 'pi pi-dollar', route: '/financial' },
   { label: 'Activity', icon: 'pi pi-receipt', route: '/log' },
+  { label: 'Wiki', icon: 'pi pi-book', route: '/wiki' },
   { label: 'Raindrop', icon: 'pi pi-chart-bar', route: '/raindrop' },
 ]
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -78,6 +78,16 @@ const router = createRouter({
       meta: { layout: 'dashboard' },
     },
     {
+      path: '/wiki',
+      component: () => import('../views/WikiView.vue'),
+      meta: { layout: 'dashboard' },
+    },
+    {
+      path: '/wiki/:noteId',
+      component: () => import('../views/WikiView.vue'),
+      meta: { layout: 'dashboard' },
+    },
+    {
       path: '/raindrop',
       component: () => import('../views/RaindropAnalyticsView.vue'),
       meta: { layout: 'dashboard' },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -286,3 +286,16 @@ export interface MyTask extends Task {
   project_name: string | null
   job_code: string | null
 }
+
+export interface WikiNote {
+  id: string
+  title: string
+  content: string
+  category: string
+  created_by: string | null
+  updated_by: string | null
+  created_by_name: string | null
+  updated_by_name: string | null
+  created_at: string | null
+  updated_at: string | null
+}

--- a/frontend/src/views/WikiView.vue
+++ b/frontend/src/views/WikiView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { WikiNote } from '../types'
 import { getWikiNotes, getWikiCategories, getWikiNote, createWikiNote, updateWikiNote, deleteWikiNote } from '../api/wiki'
@@ -62,7 +62,7 @@ async function loadNotes() {
     notes.value = noteList
     categories.value = catList
   } catch (e) {
-    toast.error('Failed to load notes')
+    toast.error('Failed to load notes: ' + String(e))
   } finally {
     loading.value = false
   }
@@ -74,8 +74,8 @@ async function selectNote(note: WikiNote) {
     editing.value = false
     creating.value = false
     router.replace(`/wiki/${note.id}`)
-  } catch {
-    toast.error('Failed to load note')
+  } catch (e) {
+    toast.error('Failed to load note: ' + String(e))
   }
 }
 
@@ -150,8 +150,8 @@ async function removeNote() {
     router.replace('/wiki')
     await loadNotes()
     toast.success('Note deleted')
-  } catch {
-    toast.error('Failed to delete note')
+  } catch (e) {
+    toast.error('Failed to delete note: ' + String(e))
   }
 }
 
@@ -190,8 +190,17 @@ onMounted(async () => {
   const noteId = route.params.noteId as string
   if (noteId) {
     const found = notes.value.find(n => n.id === noteId)
-    if (found) await selectNote(found)
+    if (found) {
+      await selectNote(found)
+    } else {
+      toast.error('Note not found — it may have been deleted')
+      router.replace('/wiki')
+    }
   }
+})
+
+onUnmounted(() => {
+  if (searchTimer) clearTimeout(searchTimer)
 })
 </script>
 

--- a/frontend/src/views/WikiView.vue
+++ b/frontend/src/views/WikiView.vue
@@ -1,0 +1,700 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { WikiNote } from '../types'
+import { getWikiNotes, getWikiCategories, getWikiNote, createWikiNote, updateWikiNote, deleteWikiNote } from '../api/wiki'
+import { uploadImage } from '../api/tasks'
+import { useToast } from '../composables/useToast'
+import { useAuth } from '../composables/useAuth'
+import MarkdownRenderer from '../components/MarkdownRenderer.vue'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const { user } = useAuth()
+
+// State
+const notes = ref<WikiNote[]>([])
+const categories = ref<string[]>([])
+const selectedNote = ref<WikiNote | null>(null)
+const loading = ref(true)
+const searchQuery = ref('')
+const selectedCategory = ref('')
+
+// Editor state
+const editing = ref(false)
+const creating = ref(false)
+const editTitle = ref('')
+const editContent = ref('')
+const editCategory = ref('General')
+const saving = ref(false)
+const showPreview = ref(false)
+const imageUploading = ref(false)
+
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+
+// Map of note title (lowercase) -> note id for wiki linking
+const noteIndex = computed(() => {
+  const map = new Map<string, string>()
+  for (const n of notes.value) {
+    map.set(n.title.toLowerCase(), n.id)
+  }
+  return map
+})
+
+const filteredNotes = computed(() => {
+  return notes.value
+})
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+async function loadNotes() {
+  loading.value = true
+  try {
+    const [noteList, catList] = await Promise.all([
+      getWikiNotes(searchQuery.value || undefined, selectedCategory.value || undefined),
+      getWikiCategories(),
+    ])
+    notes.value = noteList
+    categories.value = catList
+  } catch (e) {
+    toast.error('Failed to load notes')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function selectNote(note: WikiNote) {
+  try {
+    selectedNote.value = await getWikiNote(note.id)
+    editing.value = false
+    creating.value = false
+    router.replace(`/wiki/${note.id}`)
+  } catch {
+    toast.error('Failed to load note')
+  }
+}
+
+function startCreate() {
+  selectedNote.value = null
+  editing.value = false
+  creating.value = true
+  editTitle.value = ''
+  editContent.value = ''
+  editCategory.value = selectedCategory.value || 'General'
+  showPreview.value = false
+}
+
+function startEdit() {
+  if (!selectedNote.value) return
+  editing.value = true
+  creating.value = false
+  editTitle.value = selectedNote.value.title
+  editContent.value = selectedNote.value.content
+  editCategory.value = selectedNote.value.category
+  showPreview.value = false
+}
+
+function cancelEdit() {
+  editing.value = false
+  creating.value = false
+}
+
+async function saveNote() {
+  if (!editTitle.value.trim()) {
+    toast.error('Title is required')
+    return
+  }
+  saving.value = true
+  try {
+    if (creating.value) {
+      const created = await createWikiNote({
+        title: editTitle.value.trim(),
+        content: editContent.value,
+        category: editCategory.value.trim() || 'General',
+        created_by: user.value?.id || null,
+      })
+      creating.value = false
+      await loadNotes()
+      await selectNote(created)
+      toast.success('Note created')
+    } else if (editing.value && selectedNote.value) {
+      await updateWikiNote(selectedNote.value.id, {
+        title: editTitle.value.trim(),
+        content: editContent.value,
+        category: editCategory.value.trim() || 'General',
+        updated_by: user.value?.id || null,
+      })
+      editing.value = false
+      selectedNote.value = await getWikiNote(selectedNote.value.id)
+      await loadNotes()
+      toast.success('Note saved')
+    }
+  } catch (e) {
+    toast.error('Failed to save: ' + String(e))
+  } finally {
+    saving.value = false
+  }
+}
+
+async function removeNote() {
+  if (!selectedNote.value || !confirm('Delete this note?')) return
+  try {
+    await deleteWikiNote(selectedNote.value.id)
+    selectedNote.value = null
+    editing.value = false
+    router.replace('/wiki')
+    await loadNotes()
+    toast.success('Note deleted')
+  } catch {
+    toast.error('Failed to delete note')
+  }
+}
+
+async function handlePaste(event: ClipboardEvent) {
+  const items = event.clipboardData?.files
+  if (!items?.length) return
+  const imageFile = Array.from(items).find(f => f.type.startsWith('image/'))
+  if (!imageFile) return
+
+  event.preventDefault()
+  imageUploading.value = true
+  try {
+    const { url } = await uploadImage(imageFile)
+    const textarea = event.target as HTMLTextAreaElement
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const before = editContent.value.slice(0, start)
+    const after = editContent.value.slice(end)
+    editContent.value = before + `![image](${url})` + after
+  } catch (e) {
+    toast.error('Image upload failed: ' + String(e))
+  } finally {
+    imageUploading.value = false
+  }
+}
+
+function onSearchInput() {
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => loadNotes(), 300)
+}
+
+watch(selectedCategory, () => loadNotes())
+
+onMounted(async () => {
+  await loadNotes()
+  const noteId = route.params.noteId as string
+  if (noteId) {
+    const found = notes.value.find(n => n.id === noteId)
+    if (found) await selectNote(found)
+  }
+})
+</script>
+
+<template>
+  <div class="wiki-page">
+    <div class="page-header">
+      <h1>Wiki</h1>
+      <button class="btn-add" @click="startCreate">
+        <i class="pi pi-plus" /> New Note
+      </button>
+    </div>
+
+    <div class="wiki-layout">
+      <!-- Left Panel: Note List -->
+      <div class="wiki-sidebar">
+        <div class="sidebar-filters">
+          <div class="search-box">
+            <i class="pi pi-search" />
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search notes..."
+              @input="onSearchInput"
+            />
+            <button v-if="searchQuery" class="search-clear" @click="searchQuery = ''; loadNotes()">
+              <i class="pi pi-times" />
+            </button>
+          </div>
+          <select v-model="selectedCategory" class="category-filter">
+            <option value="">All Categories</option>
+            <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
+          </select>
+        </div>
+
+        <div v-if="loading" class="empty-state">Loading...</div>
+        <div v-else-if="notes.length === 0" class="empty-state">
+          {{ searchQuery || selectedCategory ? 'No matching notes' : 'No notes yet — create one!' }}
+        </div>
+        <div v-else class="note-list">
+          <div
+            v-for="note in filteredNotes"
+            :key="note.id"
+            class="note-item"
+            :class="{ active: selectedNote?.id === note.id }"
+            @click="selectNote(note)"
+          >
+            <div class="note-item-title">{{ note.title }}</div>
+            <div class="note-item-meta">
+              <span class="category-badge">{{ note.category }}</span>
+              <span class="note-date">{{ formatDate(note.updated_at) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right Panel: Note Detail / Editor -->
+      <div class="wiki-content">
+        <!-- Creating new note -->
+        <div v-if="creating" class="editor">
+          <input v-model="editTitle" type="text" class="edit-title" placeholder="Note title..." />
+          <div class="edit-category-row">
+            <label>Category:</label>
+            <input v-model="editCategory" type="text" class="edit-category" placeholder="General" list="wiki-categories" />
+            <datalist id="wiki-categories">
+              <option v-for="cat in categories" :key="cat" :value="cat" />
+            </datalist>
+          </div>
+          <div class="editor-toolbar">
+            <button class="toolbar-btn" :class="{ active: !showPreview }" @click="showPreview = false">Edit</button>
+            <button class="toolbar-btn" :class="{ active: showPreview }" @click="showPreview = true">Preview</button>
+            <small v-if="imageUploading" class="upload-indicator">Uploading image...</small>
+          </div>
+          <textarea
+            v-if="!showPreview"
+            v-model="editContent"
+            class="edit-textarea"
+            placeholder="Write your note in markdown..."
+            rows="20"
+            @paste="handlePaste"
+          />
+          <div v-else class="preview-panel">
+            <MarkdownRenderer :content="editContent" :note-index="noteIndex" />
+          </div>
+          <div class="editor-actions">
+            <button class="btn btn-primary" :disabled="saving" @click="saveNote">
+              {{ saving ? 'Saving...' : 'Create Note' }}
+            </button>
+            <button class="btn" @click="cancelEdit">Cancel</button>
+          </div>
+        </div>
+
+        <!-- Editing existing note -->
+        <div v-else-if="editing && selectedNote" class="editor">
+          <input v-model="editTitle" type="text" class="edit-title" placeholder="Note title..." />
+          <div class="edit-category-row">
+            <label>Category:</label>
+            <input v-model="editCategory" type="text" class="edit-category" placeholder="General" list="wiki-categories" />
+            <datalist id="wiki-categories">
+              <option v-for="cat in categories" :key="cat" :value="cat" />
+            </datalist>
+          </div>
+          <div class="editor-toolbar">
+            <button class="toolbar-btn" :class="{ active: !showPreview }" @click="showPreview = false">Edit</button>
+            <button class="toolbar-btn" :class="{ active: showPreview }" @click="showPreview = true">Preview</button>
+            <small v-if="imageUploading" class="upload-indicator">Uploading image...</small>
+          </div>
+          <textarea
+            v-if="!showPreview"
+            v-model="editContent"
+            class="edit-textarea"
+            placeholder="Write your note in markdown..."
+            rows="20"
+            @paste="handlePaste"
+          />
+          <div v-else class="preview-panel">
+            <MarkdownRenderer :content="editContent" :note-index="noteIndex" />
+          </div>
+          <div class="editor-actions">
+            <button class="btn btn-primary" :disabled="saving" @click="saveNote">
+              {{ saving ? 'Saving...' : 'Save' }}
+            </button>
+            <button class="btn" @click="cancelEdit">Cancel</button>
+          </div>
+        </div>
+
+        <!-- Viewing note -->
+        <div v-else-if="selectedNote" class="note-view">
+          <div class="note-view-header">
+            <h2>{{ selectedNote.title }}</h2>
+            <div class="note-view-actions">
+              <button class="btn btn-sm" @click="startEdit"><i class="pi pi-pencil" /> Edit</button>
+              <button class="btn btn-sm btn-danger" @click="removeNote"><i class="pi pi-trash" /> Delete</button>
+            </div>
+          </div>
+          <div class="note-view-meta">
+            <span class="category-badge">{{ selectedNote.category }}</span>
+            <span v-if="selectedNote.created_by_name" class="meta-item">
+              Created by {{ selectedNote.created_by_name }} on {{ formatDate(selectedNote.created_at) }}
+            </span>
+            <span v-if="selectedNote.updated_by_name && selectedNote.updated_by !== selectedNote.created_by" class="meta-item">
+              &middot; Updated by {{ selectedNote.updated_by_name }} on {{ formatDate(selectedNote.updated_at) }}
+            </span>
+          </div>
+          <div class="note-view-body">
+            <MarkdownRenderer :content="selectedNote.content" :note-index="noteIndex" />
+          </div>
+        </div>
+
+        <!-- Empty state -->
+        <div v-else class="empty-content">
+          <i class="pi pi-book" />
+          <p>Select a note or create a new one</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.wiki-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  height: calc(100vh - 2rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.page-header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.wiki-layout {
+  display: flex;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Left Sidebar */
+.wiki-sidebar {
+  width: 300px;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.75rem;
+}
+
+.search-box i { color: var(--p-text-muted-color); font-size: 0.75rem; }
+
+.search-box input {
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: 0.8125rem;
+  background: transparent;
+  color: var(--p-text-color);
+}
+
+.search-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.125rem;
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+}
+
+.search-clear:hover { color: var(--p-text-color); }
+
+.category-filter {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+}
+
+.note-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.note-item {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.note-item:hover {
+  border-color: var(--p-primary-color);
+  background: var(--p-content-hover-background);
+}
+
+.note-item.active {
+  border-color: var(--p-primary-color);
+  background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
+}
+
+.note-item-title {
+  font-weight: 500;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.note-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.category-badge {
+  font-size: 0.6875rem;
+  background: var(--p-content-hover-background);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+
+.note-date {
+  font-size: 0.6875rem;
+  color: var(--p-text-muted-color);
+}
+
+/* Right Content */
+.wiki-content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
+
+.empty-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--p-text-muted-color);
+  gap: 0.75rem;
+}
+
+.empty-content .pi { font-size: 2rem; }
+.empty-content p { font-size: 0.875rem; }
+
+.empty-state {
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+/* Note View */
+.note-view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.note-view-header h2 {
+  font-size: 1.375rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.note-view-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.note-view-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.meta-item {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+}
+
+/* Editor */
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.edit-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-form-field-background);
+  color: var(--p-text-color);
+  font-family: inherit;
+}
+
+.edit-category-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.edit-category-row label {
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+}
+
+.edit-category {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  background: var(--p-form-field-background);
+  color: var(--p-text-color);
+  width: 200px;
+}
+
+.editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--p-content-border-color);
+  padding-bottom: 0.5rem;
+}
+
+.toolbar-btn {
+  padding: 0.25rem 0.75rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+  border-radius: 0.25rem;
+}
+
+.toolbar-btn:hover { background: var(--p-content-hover-background); }
+
+.toolbar-btn.active {
+  color: var(--p-primary-color);
+  font-weight: 600;
+}
+
+.upload-indicator {
+  color: var(--p-primary-color);
+  font-size: 0.75rem;
+  font-style: italic;
+  margin-left: auto;
+}
+
+.edit-textarea {
+  padding: 0.75rem;
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  resize: vertical;
+  background: var(--p-form-field-background);
+  color: var(--p-text-color);
+  font-family: monospace;
+  line-height: 1.5;
+  min-height: 400px;
+}
+
+.preview-panel {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  padding: 1rem;
+  min-height: 400px;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Shared buttons */
+.btn-add {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.btn-add:hover { background: var(--p-content-hover-background); }
+.btn-add .pi { font-size: 0.625rem; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--p-text-color);
+}
+
+.btn:hover { background: var(--p-content-hover-background); }
+.btn .pi { font-size: 0.75rem; }
+
+.btn-sm { padding: 0.25rem 0.5rem; font-size: 0.75rem; }
+.btn-sm .pi { font-size: 0.625rem; }
+
+.btn-primary {
+  background: var(--p-primary-color);
+  color: #fff;
+  border-color: var(--p-primary-color);
+}
+
+.btn-primary:hover { background: var(--p-primary-hover-color); }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-danger {
+  color: var(--p-red-600);
+  border-color: var(--p-red-300);
+}
+
+.btn-danger:hover {
+  background: color-mix(in srgb, var(--p-red-600) 10%, transparent);
+}
+</style>


### PR DESCRIPTION
## Summary
- Company-wide wiki/notes section for procedures, municipality info, production tips
- Markdown editing with live preview (marked + DOMPurify)
- Clipboard image paste support (reuses existing upload API)
- `[[Page Title]]` wiki linking between notes (missing links shown in red)
- Category filtering and search
- Image cleanup on note deletion
- New sidebar nav item, two-panel layout

## Test plan
- [ ] Navigate to /wiki, verify empty state
- [ ] Create a note with markdown (headings, lists, code blocks, tables, bold/italic)
- [ ] Paste an image into the editor, verify upload and rendering
- [ ] Test Edit/Preview toggle in editor
- [ ] Test category filtering and search
- [ ] Create two notes, link them with `[[Note Title]]` syntax, verify navigation
- [ ] Delete a note with images, verify images removed from uploads/
- [ ] Check table headers in dark mode for readability
- [ ] Run migration 027 on fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)