### PR TITLE
Unify task/note create forms with Cancel/Create buttons

### DIFF
--- a/frontend/src/components/project/ProjectNotes.vue
+++ b/frontend/src/components/project/ProjectNotes.vue
@@ -60,6 +60,11 @@ async function submitNote() {
   }
 }
 
+function cancelNewNote() {
+  newNote.value = ''
+  sessionStorage.removeItem(draftKey())
+}
+
 function startEditNote(note: ProjectNote) {
   editingNoteId.value = note.id
   editNoteContent.value = note.content
@@ -167,9 +172,12 @@ defineExpose({ notesCount: computed(() => notes.value.length), loadNotes })
     <div class="add-note">
       <textarea v-model="newNote" rows="2" placeholder="Add a note..." class="note-input" @paste="onNotePaste" />
       <small v-if="noteImageUploading" class="upload-indicator">Uploading image...</small>
-      <button class="btn btn-sm btn-primary" :disabled="noteSaving" @click="submitNote">
-        {{ noteSaving ? 'Adding...' : 'Add Note' }}
-      </button>
+      <div class="add-note-actions">
+        <button class="btn btn-sm" :disabled="noteSaving || !newNote" @click="cancelNewNote">Cancel</button>
+        <button class="btn btn-sm btn-primary" :disabled="noteSaving || !newNote.trim()" @click="submitNote">
+          {{ noteSaving ? 'Adding...' : 'Add Note' }}
+        </button>
+      </div>
     </div>
 
     <div v-if="notes.length > 1" class="note-search">
@@ -225,6 +233,12 @@ defineExpose({ notesCount: computed(() => notes.value.length), loadNotes })
   background: var(--p-content-background);
   color: var(--p-text-color);
   font-family: inherit;
+}
+
+.add-note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .upload-indicator { color: var(--p-primary-color); font-size: 0.75rem; font-style: italic; }

--- a/frontend/src/components/project/ProjectTasks.vue
+++ b/frontend/src/components/project/ProjectTasks.vue
@@ -148,6 +148,14 @@ function openTaskDetail(taskId: string) {
   emit('entityClicked', 'task', taskId)
 }
 
+function cancelNewTask() {
+  newTaskTitle.value = ''
+  newTaskDueDate.value = todayStr()
+  newTaskDescription.value = ''
+  newTaskAssigneeIds.value = []
+  showNewTaskForm.value = false
+}
+
 function toggleNewTaskAssignee(empId: string) {
   const idx = newTaskAssigneeIds.value.indexOf(empId)
   if (idx >= 0) {
@@ -219,8 +227,8 @@ defineExpose({ totalTaskCount, loadTasks })
   <div class="section">
     <div class="section-header tasks-header">
       <h4>Tasks</h4>
-      <button class="btn-icon" :title="showNewTaskForm ? 'Cancel' : 'Add task'" @click="showNewTaskForm = !showNewTaskForm; if (showNewTaskForm && user) newTaskAssigneeIds = [user.id]">
-        <i class="pi" :class="showNewTaskForm ? 'pi-times' : 'pi-plus'" />
+      <button v-if="!showNewTaskForm" class="btn-icon" title="Add task" @click="showNewTaskForm = true; if (user) newTaskAssigneeIds = [user.id]">
+        <i class="pi pi-plus" />
       </button>
     </div>
 
@@ -243,9 +251,12 @@ defineExpose({ totalTaskCount, loadTasks })
           </button>
         </div>
       </div>
-      <button class="btn btn-sm btn-primary" :disabled="newTaskSaving || !newTaskTitle.trim()" @click="submitNewTask">
-        {{ newTaskSaving ? 'Creating...' : 'Create' }}
-      </button>
+      <div class="new-task-actions">
+        <button class="btn btn-sm" :disabled="newTaskSaving" @click="cancelNewTask">Cancel</button>
+        <button class="btn btn-sm btn-primary" :disabled="newTaskSaving || !newTaskTitle.trim()" @click="submitNewTask">
+          {{ newTaskSaving ? 'Creating...' : 'Create' }}
+        </button>
+      </div>
     </div>
 
     <!-- Task search -->
@@ -589,6 +600,12 @@ defineExpose({ totalTaskCount, loadTasks })
   color: var(--p-text-muted-color);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.new-task-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .assignee-chips {


### PR DESCRIPTION
## Summary
- Task create: removed top X toggle, added Cancel + Create buttons at bottom right
- Note create: added Cancel button next to Add Note at bottom right
- Both use a flex-end actions row; Cancel clears form/draft

## Test plan
- [ ] Open a project, click + on Tasks, verify Cancel/Create at bottom right
- [ ] Verify Cancel clears fields and hides form
- [ ] On Notes, type a draft then click Cancel — draft clears
- [ ] Submit a note and a task to confirm nothing broke