### PR TITLE
feat: task tags, pinning, bulk actions, manual reorder, contact group…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,4 +100,11 @@ async def vue_spa_fallback(path: str):
     file_path = vue_dist / path
     if file_path.is_file():
         return FileResponse(file_path)
-    return FileResponse(vue_dist / "index.html")
+    # index.html must always be fetched fresh so the browser picks up new
+    # hashed JS bundles after a deploy.  Without this, browsers use heuristic
+    # caching on the ETag/Last-Modified and serve a stale index.html that
+    # references old chunk hashes.
+    return FileResponse(
+        vue_dist / "index.html",
+        headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+    )

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -33,6 +33,8 @@ class TaskCreate(BaseModel):
     priority: int | None = None
     sort_order: int = 0
     assignee_ids: list[str] | None = None
+    is_pinned: bool = False
+    tags: list[str] | None = None
 
 
 class TaskUpdate(BaseModel):
@@ -46,6 +48,8 @@ class TaskUpdate(BaseModel):
     parent_id: str | None = None
     sort_order: int | None = None
     assignee_ids: list[str] | None = None
+    is_pinned: bool | None = None
+    tags: list[str] | None = None
 
 
 class TaskResponse(BaseModel):
@@ -65,6 +69,8 @@ class TaskResponse(BaseModel):
     created_at: datetime | str | None = None
     updated_at: datetime | str | None = None
     is_stale: bool = False
+    is_pinned: bool = False
+    tags: list[str] = []
     assignees: list[dict] = []
     notes: list[dict] = []
     subtasks: list[dict] = []
@@ -75,8 +81,24 @@ class TaskBulkPatch(BaseModel):
     status: str | None = None
     assignee_ids: list[str] | None = None
     priority: int | None = None
+    is_pinned: bool | None = None
+    tags: list[str] | None = None
+    add_tags: list[str] | None = None
 
 
 class TaskBulkRequest(BaseModel):
     task_ids: list[str]
     patch: TaskBulkPatch
+
+
+class TaskBulkDeleteRequest(BaseModel):
+    task_ids: list[str]
+
+
+class TaskReorderItem(BaseModel):
+    task_id: str
+    sort_order: int
+
+
+class TaskReorderRequest(BaseModel):
+    items: list[TaskReorderItem]

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -5,18 +5,20 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from ..database import get_db
 from ..events import event_bus
 from ..models.task import (
+    TaskBulkDeleteRequest,
     TaskBulkRequest,
     TaskCreate,
     TaskNoteCreate,
     TaskNoteResponse,
     TaskNoteUpdate,
+    TaskReorderRequest,
     TaskResponse,
     TaskUpdate,
 )
 from ..utils import generate_id
 
 STALE_DAYS = 30
-BULK_ALLOWED_FIELDS = {"due_date", "status", "assignee_ids", "priority"}
+BULK_ALLOWED_FIELDS = {"due_date", "status", "assignee_ids", "priority", "is_pinned", "tags", "add_tags"}
 
 router = APIRouter()
 
@@ -143,7 +145,7 @@ def list_project_tasks(
             "WHERE a.task_id = t.id AND a.employee_id = %s)"
         )
         params.append(assignee)
-    sql += " ORDER BY t.sort_order, t.created_at"
+    sql += " ORDER BY t.is_pinned DESC, t.sort_order, t.created_at"
     rows = db.execute(sql, tuple(params)).fetchall()
     return [_build_task_response(db, row) for row in rows]
 
@@ -162,13 +164,13 @@ def create_task(project_id: str, data: TaskCreate, db=Depends(get_db)):
     start_date = str(data.start_date) if data.start_date else now[:10]  # default to today
     db.execute(
         "INSERT INTO project_tasks "
-        "(id, project_id, parent_id, title, description, status, priority, start_date, due_date, reminder_at, sort_order, created_at, updated_at) "
-        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        "(id, project_id, parent_id, title, description, status, priority, start_date, due_date, reminder_at, sort_order, is_pinned, tags, created_at, updated_at) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
         (task_id, project_id, data.parent_id, data.title, data.description,
          data.status, data.priority, start_date,
          str(data.due_date) if data.due_date else None,
          str(data.reminder_at) if data.reminder_at else None,
-         data.sort_order, now, now),
+         data.sort_order, data.is_pinned, data.tags or [], now, now),
     )
 
     if data.assignee_ids:
@@ -191,19 +193,30 @@ def list_my_tasks(
     stale: bool | None = Query(None),
     status: str | None = Query(None),
     no_due_date: bool | None = Query(None),
+    assignee_ids: str | None = Query(None, description="Comma-separated employee IDs to filter by"),
+    tags: str | None = Query(None, description="Comma-separated tags to filter by (ANY match)"),
     db=Depends(get_db),
 ):
+    """Return tasks assigned to the given employee, or to any of the given assignee_ids."""
+    # Build the assignee filter set: if assignee_ids is provided, use those;
+    # otherwise default to employee_id (the original "my tasks" behavior).
+    if assignee_ids:
+        filter_ids = [s.strip() for s in assignee_ids.split(",") if s.strip()]
+    else:
+        filter_ids = [employee_id]
+
+    placeholders = ", ".join(["%s"] * len(filter_ids))
     sql = (
-        "SELECT t.*, p.name AS project_name, p.job_code "
+        "SELECT DISTINCT t.*, p.name AS project_name, p.job_code "
         "FROM project_tasks t "
         "JOIN project_task_assignees a ON a.task_id = t.id "
         "JOIN projects p ON p.id = t.project_id "
-        "WHERE a.employee_id = %s "
+        f"WHERE a.employee_id IN ({placeholders}) "
         "AND t.deleted_at IS NULL "
         "AND p.deleted_at IS NULL "
         "AND t.parent_id IS NULL"
     )
-    params: list = [employee_id]
+    params: list = list(filter_ids)
     if due_before is not None:
         sql += " AND t.due_date <= %s"
         params.append(str(due_before))
@@ -220,7 +233,12 @@ def list_my_tasks(
         cutoff = (datetime.now() - timedelta(days=STALE_DAYS)).isoformat()
         sql += " AND t.updated_at < %s AND t.status NOT IN ('done','archived','canceled')"
         params.append(cutoff)
-    sql += " ORDER BY t.due_date ASC NULLS LAST, t.created_at DESC"
+    # Tag filter: task must have at least one of the specified tags
+    tag_list = _parse_status_csv(tags)  # same CSV parsing logic
+    if tag_list:
+        sql += " AND t.tags && %s::text[]"
+        params.append(tag_list)
+    sql += " ORDER BY t.is_pinned DESC, t.due_date ASC NULLS LAST, t.created_at DESC"
     rows = db.execute(sql, tuple(params)).fetchall()
     result = []
     for row in rows:
@@ -251,7 +269,7 @@ def list_done_today(
         "AND t.parent_id IS NULL "
         "AND t.completed_at >= %s "
         "AND t.completed_at < %s "
-        "ORDER BY t.completed_at DESC",
+        "ORDER BY t.is_pinned DESC, t.completed_at DESC",
         (employee_id, str(day), str(day + timedelta(days=1))),
     ).fetchall()
     result = []
@@ -278,7 +296,7 @@ def bulk_update_tasks(data: TaskBulkRequest, db=Depends(get_db)):
         raise HTTPException(status_code=400, detail="patch must include at least one field")
 
     rows = db.execute(
-        "SELECT id, status FROM project_tasks WHERE id = ANY(%s) AND deleted_at IS NULL",
+        "SELECT id, status, tags FROM project_tasks WHERE id = ANY(%s) AND deleted_at IS NULL",
         (data.task_ids,),
     ).fetchall()
     found = {r["id"]: dict(r) for r in rows}
@@ -296,6 +314,20 @@ def bulk_update_tasks(data: TaskBulkRequest, db=Depends(get_db)):
             updates["due_date"] = str(patch.due_date) if patch.due_date else None
         if "priority" in fields_set:
             updates["priority"] = patch.priority
+        if "is_pinned" in fields_set:
+            updates["is_pinned"] = patch.is_pinned
+        if "tags" in fields_set:
+            updates["tags"] = patch.tags if patch.tags is not None else []
+        if "add_tags" in fields_set and patch.add_tags:
+            # add_tags merges on top of tags (if both sent), then existing DB tags
+            base = updates.get("tags")
+            if base is None:
+                base = found[tid].get("tags") or []
+            merged = list(base)
+            for t in patch.add_tags:
+                if t not in merged:
+                    merged.append(t)
+            updates["tags"] = merged
         if "status" in fields_set:
             updates["status"] = patch.status
             existing_status = found[tid]["status"]
@@ -330,6 +362,71 @@ def bulk_update_tasks(data: TaskBulkRequest, db=Depends(get_db)):
         (updated_ids,),
     ).fetchall()
     return [_build_task_response(db, r) for r in result_rows]
+
+
+@router.patch("/tasks/reorder")
+def reorder_tasks(data: TaskReorderRequest, db=Depends(get_db)):
+    """Set sort_order for multiple tasks in a single request."""
+    if not data.items:
+        raise HTTPException(status_code=400, detail="items cannot be empty")
+    task_ids = [item.task_id for item in data.items]
+    rows = db.execute(
+        "SELECT id FROM project_tasks WHERE id = ANY(%s) AND deleted_at IS NULL",
+        (task_ids,),
+    ).fetchall()
+    found = {r["id"] for r in rows}
+    missing = [tid for tid in task_ids if tid not in found]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"Tasks not found: {missing}")
+    now = datetime.now().isoformat()
+    for item in data.items:
+        db.execute(
+            "UPDATE project_tasks SET sort_order = %s, updated_at = %s WHERE id = %s",
+            (item.sort_order, now, item.task_id),
+        )
+    db.commit()
+    project_rows = db.execute(
+        "SELECT DISTINCT project_id FROM project_tasks WHERE id = ANY(%s)",
+        (task_ids,),
+    ).fetchall()
+    for r in project_rows:
+        event_bus.publish(r["project_id"], "task_updated", r["project_id"])
+    return {"success": True}
+
+
+@router.delete("/tasks/bulk")
+def bulk_delete_tasks(data: TaskBulkDeleteRequest, db=Depends(get_db)):
+    """Soft-delete multiple tasks (and their subtasks) in a single request."""
+    if not data.task_ids:
+        raise HTTPException(status_code=400, detail="task_ids cannot be empty")
+
+    rows = db.execute(
+        "SELECT id, project_id FROM project_tasks WHERE id = ANY(%s) AND deleted_at IS NULL",
+        (data.task_ids,),
+    ).fetchall()
+    found = {r["id"]: dict(r) for r in rows}
+    missing = [tid for tid in data.task_ids if tid not in found]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"Tasks not found: {missing}")
+
+    now = datetime.now().isoformat()
+    # Soft-delete subtasks of each selected task
+    db.execute(
+        "UPDATE project_tasks SET deleted_at = %s WHERE parent_id = ANY(%s) AND deleted_at IS NULL",
+        (now, data.task_ids),
+    )
+    # Soft-delete the selected tasks themselves
+    db.execute(
+        "UPDATE project_tasks SET deleted_at = %s WHERE id = ANY(%s)",
+        (now, data.task_ids),
+    )
+    db.commit()
+
+    for tid in data.task_ids:
+        pid = found[tid]["project_id"]
+        event_bus.publish(pid, "task_deleted", tid)
+
+    return {"success": True, "deleted_count": len(data.task_ids)}
 
 
 # --- Task Notes (registered before /tasks/{task_id} to avoid route shadowing) ---
@@ -412,6 +509,17 @@ def delete_note(note_id: str, db=Depends(get_db)):
 
 # --- Single-task endpoints ---
 
+@router.get("/tasks/tags")
+def list_all_tags(db=Depends(get_db)):
+    """Return all distinct tags used across non-deleted tasks."""
+    rows = db.execute(
+        "SELECT DISTINCT unnest(tags) AS tag FROM project_tasks "
+        "WHERE deleted_at IS NULL AND tags != '{}' "
+        "ORDER BY tag ASC"
+    ).fetchall()
+    return [r["tag"] for r in rows]
+
+
 @router.get("/tasks/{task_id}", response_model=TaskResponse)
 def get_task(task_id: str, db=Depends(get_db)):
     row = db.execute(
@@ -434,6 +542,9 @@ def update_task(task_id: str, data: TaskUpdate, db=Depends(get_db)):
     dump = data.model_dump(exclude_unset=True)
     for k, v in dump.items():
         if k == "assignee_ids":
+            continue
+        if k == "tags":
+            updates[k] = v if v is not None else []
             continue
         if v is None:
             updates[k] = None

--- a/db/migrations/032_add_pinned_and_tags.sql
+++ b/db/migrations/032_add_pinned_and_tags.sql
@@ -1,0 +1,8 @@
+-- Add is_pinned and tags columns to project_tasks
+ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS is_pinned BOOLEAN DEFAULT FALSE;
+ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT '{}';
+
+-- Index for pinned tasks (used in sorting queries)
+CREATE INDEX IF NOT EXISTS idx_project_tasks_pinned ON project_tasks(is_pinned);
+-- GIN index for tag array queries
+CREATE INDEX IF NOT EXISTS idx_project_tasks_tags ON project_tasks USING GIN (tags);

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -7,6 +7,8 @@ export interface MyTaskFilters {
   stale?: boolean
   status?: string
   no_due_date?: boolean
+  assignee_ids?: string[]
+  tags?: string[]
 }
 
 export function getMyTasks(employeeId: string, filters?: MyTaskFilters): Promise<MyTask[]> {
@@ -16,6 +18,8 @@ export function getMyTasks(employeeId: string, filters?: MyTaskFilters): Promise
   if (filters?.stale) params.set('stale', 'true')
   if (filters?.status) params.set('status', filters.status)
   if (filters?.no_due_date) params.set('no_due_date', 'true')
+  if (filters?.assignee_ids?.length) params.set('assignee_ids', filters.assignee_ids.join(','))
+  if (filters?.tags?.length) params.set('tags', filters.tags.join(','))
   return apiFetch(`/tasks/my?${params.toString()}`)
 }
 
@@ -29,12 +33,33 @@ export interface BulkPatchFields {
   status?: string
   assignee_ids?: string[]
   priority?: number | null
+  is_pinned?: boolean
+  tags?: string[]
+  add_tags?: string[]
 }
 
 export function bulkUpdateTasks(taskIds: string[], patch: BulkPatchFields): Promise<MyTask[]> {
   return apiFetch('/tasks/bulk', {
     method: 'PATCH',
     body: JSON.stringify({ task_ids: taskIds, patch }),
+  })
+}
+
+export function bulkDeleteTasks(taskIds: string[]): Promise<{ success: boolean; deleted_count: number }> {
+  return apiFetch('/tasks/bulk', {
+    method: 'DELETE',
+    body: JSON.stringify({ task_ids: taskIds }),
+  })
+}
+
+export function getTags(): Promise<string[]> {
+  return apiFetch('/tasks/tags')
+}
+
+export function reorderTasks(items: { task_id: string; sort_order: number }[]): Promise<{ success: boolean }> {
+  return apiFetch('/tasks/reorder', {
+    method: 'PATCH',
+    body: JSON.stringify({ items }),
   })
 }
 

--- a/frontend/src/components/dashboard/ProjectDetail.vue
+++ b/frontend/src/components/dashboard/ProjectDetail.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, watch, computed, onBeforeUnmount } from 'vue'
-import type { ProjectDetail as ProjectDetailType, ProjectNote, Task, ProjectContact, Contact } from '../../types'
+import type { ProjectDetail as ProjectDetailType, ProjectNote, Task, ProjectContact, Contact, Client } from '../../types'
 import { getProjectNotes, addProjectNote, updateProjectNote, deleteProjectNote, getProjectContacts, addProjectContact, removeProjectContact } from '../../api/projects'
 import { getContacts, createContact } from '../../api/contacts'
+import { getClients } from '../../api/clients'
 import { getProjectTasks, createTask, updateTask } from '../../api/tasks'
 import { generateDoc, exportProposalPdf, sendProposal } from '../../api/proposals'
 import { generateSheet, exportPdf as exportInvoicePdfApi } from '../../api/invoices'
@@ -110,13 +111,17 @@ const teamContacts = ref<ProjectContact[]>([])
 const teamLoading = ref(false)
 const showAddContact = ref(false)
 const allContacts = ref<Contact[]>([])
+const allClients = ref<Client[]>([])
 const addContactId = ref('')
 const addContactRole = ref('')
 const addContactSaving = ref(false)
 const showNewContactInline = ref(false)
-const newContactName = ref('')
+const newContactFirstName = ref('')
+const newContactLastName = ref('')
 const newContactEmail = ref('')
+const newContactPhone = ref('')
 const newContactRole = ref('')
+const newContactClientId = ref('')
 const creatingNewContact = ref(false)
 
 const ROLE_SUGGESTIONS = [
@@ -131,9 +136,39 @@ const ROLE_SUGGESTIONS = [
   'Reviewer',
 ]
 
-const availableContacts = computed(() => {
+// Contacts from the project's company, sorted by name
+const projectCompanyContacts = computed(() => {
   const linked = new Set(teamContacts.value.map(c => c.contact_id))
-  return allContacts.value.filter(c => !linked.has(c.id))
+  const clientId = props.project.client_id
+  return allContacts.value
+    .filter(c => c.client_id === clientId && !linked.has(c.id))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+// Other contacts grouped by company
+const otherContactsGrouped = computed(() => {
+  const linked = new Set(teamContacts.value.map(c => c.contact_id))
+  const clientId = props.project.client_id
+  const others = allContacts.value
+    .filter(c => c.client_id !== clientId && !linked.has(c.id))
+    .sort((a, b) => a.name.localeCompare(b.name))
+  const groups: { companyName: string; contacts: Contact[] }[] = []
+  for (const c of others) {
+    const client = allClients.value.find(cl => cl.id === c.client_id)
+    const companyName = client?.name ?? 'No Company'
+    let group = groups.find(g => g.companyName === companyName)
+    if (!group) {
+      group = { companyName, contacts: [] }
+      groups.push(group)
+    }
+    group.contacts.push(c)
+  }
+  return groups
+})
+
+const projectCompanyName = computed(() => {
+  const client = allClients.value.find(cl => cl.id === props.project.client_id)
+  return client?.name ?? 'Project Company'
 })
 
 // Time tracking state
@@ -250,8 +285,14 @@ async function openAddContact() {
   addContactId.value = ''
   addContactRole.value = ''
   showNewContactInline.value = false
+  newContactClientId.value = props.project.client_id || ''
   try {
-    allContacts.value = await getContacts(props.project.client_id || undefined)
+    const [contacts, clients] = await Promise.all([
+      getContacts(),
+      getClients(),
+    ])
+    allContacts.value = contacts
+    allClients.value = clients
   } catch (e) {
     console.error('Failed to load contacts:', e)
   }
@@ -276,14 +317,17 @@ async function submitAddContact() {
 }
 
 async function submitNewTeamContact() {
-  if (!newContactName.value.trim()) return
+  const firstName = newContactFirstName.value.trim()
+  if (!firstName) return
   creatingNewContact.value = true
   try {
+    const fullName = [firstName, newContactLastName.value.trim()].filter(Boolean).join(' ')
     const contact = await createContact({
-      name: newContactName.value.trim(),
+      name: fullName,
       email: newContactEmail.value.trim() || undefined,
+      phone: newContactPhone.value.trim() || undefined,
       role: newContactRole.value || undefined,
-      client_id: props.project.client_id || undefined,
+      client_id: newContactClientId.value || undefined,
     })
     await addProjectContact(props.project.id, {
       contact_id: contact.id,
@@ -291,9 +335,12 @@ async function submitNewTeamContact() {
     })
     showNewContactInline.value = false
     showAddContact.value = false
-    newContactName.value = ''
+    newContactFirstName.value = ''
+    newContactLastName.value = ''
     newContactEmail.value = ''
+    newContactPhone.value = ''
     newContactRole.value = ''
+    newContactClientId.value = ''
     toast.success('Contact created and added to team')
     await loadTeam()
   } catch (e) {
@@ -1017,9 +1064,16 @@ function formatPercent(value: number): string {
           <div class="add-contact-row">
             <select v-model="addContactId" class="contact-select">
               <option value="">-- Select contact --</option>
-              <option v-for="c in availableContacts" :key="c.id" :value="c.id">
-                {{ c.name }}{{ c.email ? ` (${c.email})` : '' }}
-              </option>
+              <optgroup v-if="projectCompanyContacts.length" :label="projectCompanyName">
+                <option v-for="c in projectCompanyContacts" :key="c.id" :value="c.id">
+                  {{ c.name }}{{ c.email ? ` — ${c.email}` : '' }}
+                </option>
+              </optgroup>
+              <optgroup v-for="group in otherContactsGrouped" :key="group.companyName" :label="group.companyName">
+                <option v-for="c in group.contacts" :key="c.id" :value="c.id">
+                  {{ c.name }}{{ c.email ? ` — ${c.email}` : '' }}
+                </option>
+              </optgroup>
             </select>
             <select v-model="addContactRole" class="role-select">
               <option value="">-- Role --</option>
@@ -1029,20 +1083,35 @@ function formatPercent(value: number): string {
               Add
             </button>
           </div>
+
+          <div class="new-contact-divider"><span>or</span></div>
+
           <div class="new-contact-toggle">
             <button class="btn-link" @click="showNewContactInline = !showNewContactInline">
-              {{ showNewContactInline ? 'Cancel' : '+ New contact' }}
+              {{ showNewContactInline ? 'Cancel new contact' : '+ Add new contact' }}
             </button>
           </div>
-          <div v-if="showNewContactInline" class="add-contact-row">
-            <input v-model="newContactName" type="text" placeholder="Name" class="contact-input" />
-            <input v-model="newContactEmail" type="email" placeholder="Email" class="contact-input" />
-            <select v-model="newContactRole" class="role-select">
-              <option value="">-- Role --</option>
-              <option v-for="r in ROLE_SUGGESTIONS" :key="r" :value="r">{{ r }}</option>
-            </select>
-            <button class="btn btn-sm btn-primary" :disabled="!newContactName.trim() || creatingNewContact" @click="submitNewTeamContact">
-              Create & Add
+          <div v-if="showNewContactInline" class="new-contact-form">
+            <div class="add-contact-row">
+              <input v-model="newContactFirstName" type="text" placeholder="First name" class="contact-input" />
+              <input v-model="newContactLastName" type="text" placeholder="Last name" class="contact-input" />
+            </div>
+            <div class="add-contact-row">
+              <input v-model="newContactEmail" type="email" placeholder="Email" class="contact-input" />
+              <input v-model="newContactPhone" type="tel" placeholder="Phone" class="contact-input" />
+            </div>
+            <div class="add-contact-row">
+              <select v-model="newContactClientId" class="company-select">
+                <option value="">-- Affiliated company --</option>
+                <option v-for="cl in allClients" :key="cl.id" :value="cl.id">{{ cl.name }}</option>
+              </select>
+              <select v-model="newContactRole" class="role-select">
+                <option value="">-- Role --</option>
+                <option v-for="r in ROLE_SUGGESTIONS" :key="r" :value="r">{{ r }}</option>
+              </select>
+            </div>
+            <button class="btn btn-sm btn-primary" :disabled="!newContactFirstName.trim() || creatingNewContact" @click="submitNewTeamContact">
+              {{ creatingNewContact ? 'Creating...' : 'Create & Add' }}
             </button>
           </div>
         </div>
@@ -1885,9 +1954,46 @@ function formatPercent(value: number): string {
   color: var(--p-text-color);
 }
 
-.contact-select { flex: 2; min-width: 0; }
-.role-select { flex: 1; min-width: 0; }
-.contact-input { flex: 1; min-width: 0; }
+.contact-select { flex: 2; min-width: 200px; }
+.role-select { flex: 1; min-width: 120px; }
+.contact-input { flex: 1; min-width: 120px; }
+.company-select {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  background: var(--p-form-field-background);
+  color: var(--p-text-color);
+  flex: 2;
+  min-width: 180px;
+}
+
+.new-contact-divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+  margin: 0.25rem 0;
+}
+.new-contact-divider::before,
+.new-contact-divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--p-content-border-color);
+}
+.new-contact-divider span {
+  padding: 0 0.5rem;
+}
+
+.new-contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px dashed var(--p-content-border-color);
+  border-radius: 0.375rem;
+}
 
 .new-contact-toggle {
   display: flex;

--- a/frontend/src/components/modals/ProjectModal.vue
+++ b/frontend/src/components/modals/ProjectModal.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import Dialog from 'primevue/dialog'
-import type { ProjectSummary, Contact, Employee } from '../../types'
+import type { ProjectSummary, Contact, Employee, Client } from '../../types'
 import { useClients } from '../../composables/useClients'
 import { useToast } from '../../composables/useToast'
 import { createProject, updateProject } from '../../api/projects'
 import { getEmployees } from '../../api/employees'
 import { getContacts, createContact } from '../../api/contacts'
+import { getClients } from '../../api/clients'
 
 const visible = defineModel<boolean>('visible', { required: true })
 
@@ -23,10 +24,14 @@ const emit = defineEmits<{
 const { clients } = useClients()
 const toast = useToast()
 const employees = ref<Employee[]>([])
-const contacts = ref<Contact[]>([])
+const allContacts = ref<Contact[]>([])
+const allClients = ref<Client[]>([])
 const showNewContact = ref(false)
-const newContactName = ref('')
+const newContactFirstName = ref('')
+const newContactLastName = ref('')
 const newContactEmail = ref('')
+const newContactPhone = ref('')
+const newContactClientId = ref('')
 const creatingContact = ref(false)
 
 const form = ref({
@@ -47,6 +52,39 @@ const form = ref({
 
 const saving = ref(false)
 
+// Computed: contacts from the project's company, sorted by name
+const projectCompanyContacts = computed(() => {
+  const clientId = form.value.client_id
+  return allContacts.value
+    .filter(c => c.client_id === clientId)
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+// Computed: other contacts grouped by company name
+const otherContactsGrouped = computed(() => {
+  const clientId = form.value.client_id
+  const others = allContacts.value
+    .filter(c => c.client_id !== clientId)
+    .sort((a, b) => a.name.localeCompare(b.name))
+  const groups: { companyName: string; contacts: Contact[] }[] = []
+  for (const c of others) {
+    const client = allClients.value.find(cl => cl.id === c.client_id)
+    const companyName = client?.name ?? 'No Company'
+    let group = groups.find(g => g.companyName === companyName)
+    if (!group) {
+      group = { companyName, contacts: [] }
+      groups.push(group)
+    }
+    group.contacts.push(c)
+  }
+  return groups
+})
+
+const projectCompanyName = computed(() => {
+  const client = allClients.value.find(cl => cl.id === form.value.client_id)
+  return client?.name ?? 'Project Company'
+})
+
 function normalizeDataPath(raw: string): string {
   let p = raw.trim()
   if (p.startsWith('"') && p.endsWith('"')) p = p.slice(1, -1)
@@ -56,23 +94,28 @@ function normalizeDataPath(raw: string): string {
   return p
 }
 
-async function loadContacts(clientId: string) {
-  if (!clientId) {
-    contacts.value = []
-    return
-  }
-  contacts.value = await getContacts(clientId)
+async function loadAllContactsAndClients() {
+  const [contacts, clients] = await Promise.all([
+    getContacts(),
+    getClients(),
+  ])
+  allContacts.value = contacts
+  allClients.value = clients
 }
 
-// Watch client_id changes to load contacts and auto-select first
+// Watch client_id changes to auto-select first contact from that company
 watch(() => form.value.client_id, async (newClientId, oldClientId) => {
   if (newClientId !== oldClientId) {
     showNewContact.value = false
-    newContactName.value = ''
+    newContactFirstName.value = ''
+    newContactLastName.value = ''
     newContactEmail.value = ''
-    await loadContacts(newClientId || '')
-    if (contacts.value.length > 0 && contacts.value[0]) {
-      form.value.client_pm_id = contacts.value[0].id
+    newContactPhone.value = ''
+    newContactClientId.value = newClientId || ''
+    // Auto-select first contact from the project's company if none selected
+    const companyContacts = allContacts.value.filter(c => c.client_id === newClientId)
+    if (companyContacts.length > 0 && companyContacts[0]) {
+      form.value.client_pm_id = companyContacts[0].id
     } else {
       form.value.client_pm_id = ''
     }
@@ -82,6 +125,7 @@ watch(() => form.value.client_id, async (newClientId, oldClientId) => {
 watch(visible, async (val) => {
   if (!val) return
   employees.value = await getEmployees()
+  await loadAllContactsAndClients()
   if (props.project) {
     form.value = {
       project_name: props.project.project_name || '',
@@ -98,10 +142,7 @@ watch(visible, async (val) => {
       data_path: props.project.data_path || '',
       notes: '',
     }
-    // Load contacts for the existing client without overwriting client_pm_id
-    if (props.project.client_id) {
-      await loadContacts(props.project.client_id)
-    }
+    newContactClientId.value = props.project.client_id || ''
   } else {
     form.value = {
       project_name: '',
@@ -118,27 +159,33 @@ watch(visible, async (val) => {
       data_path: '',
       notes: '',
     }
-    contacts.value = []
   }
   showNewContact.value = false
-  newContactName.value = ''
+  newContactFirstName.value = ''
+  newContactLastName.value = ''
   newContactEmail.value = ''
+  newContactPhone.value = ''
 })
 
 async function addContact() {
-  if (!newContactName.value.trim()) return
+  const firstName = newContactFirstName.value.trim()
+  if (!firstName) return
   creatingContact.value = true
   try {
+    const fullName = [firstName, newContactLastName.value.trim()].filter(Boolean).join(' ')
     const contact = await createContact({
-      name: newContactName.value.trim(),
+      name: fullName,
       email: newContactEmail.value.trim() || undefined,
-      client_id: form.value.client_id,
+      phone: newContactPhone.value.trim() || undefined,
+      client_id: newContactClientId.value || form.value.client_id || undefined,
     })
-    contacts.value.push(contact)
+    allContacts.value.push(contact)
     form.value.client_pm_id = contact.id
     showNewContact.value = false
-    newContactName.value = ''
+    newContactFirstName.value = ''
+    newContactLastName.value = ''
     newContactEmail.value = ''
+    newContactPhone.value = ''
   } catch (e) {
     toast.error('Failed to create contact')
   } finally {
@@ -256,27 +303,51 @@ async function save() {
           </div>
           <select v-model="form.client_pm_id">
             <option value="">-- None --</option>
-            <option v-for="ct in contacts" :key="ct.id" :value="ct.id">
-              {{ ct.name }}{{ ct.email ? ` (${ct.email})` : '' }}
-            </option>
+            <optgroup v-if="projectCompanyContacts.length" :label="projectCompanyName">
+              <option v-for="ct in projectCompanyContacts" :key="ct.id" :value="ct.id">
+                {{ ct.name }}{{ ct.email ? ` — ${ct.email}` : '' }}
+              </option>
+            </optgroup>
+            <optgroup v-for="group in otherContactsGrouped" :key="group.companyName" :label="group.companyName">
+              <option v-for="ct in group.contacts" :key="ct.id" :value="ct.id">
+                {{ ct.name }}{{ ct.email ? ` — ${ct.email}` : '' }}
+              </option>
+            </optgroup>
           </select>
           <div v-if="showNewContact" class="new-contact-form">
             <div class="field-row">
               <div class="field">
-                <input v-model="newContactName" type="text" placeholder="Name" />
+                <input v-model="newContactFirstName" type="text" placeholder="First name" />
               </div>
+              <div class="field">
+                <input v-model="newContactLastName" type="text" placeholder="Last name" />
+              </div>
+            </div>
+            <div class="field-row">
               <div class="field">
                 <input v-model="newContactEmail" type="email" placeholder="Email" />
               </div>
-              <button
-                type="button"
-                class="btn btn-sm"
-                :disabled="!newContactName.trim() || creatingContact"
-                @click="addContact"
-              >
-                Add
-              </button>
+              <div class="field">
+                <input v-model="newContactPhone" type="tel" placeholder="Phone" />
+              </div>
             </div>
+            <div class="field-row">
+              <div class="field">
+                <label>Affiliated Company</label>
+                <select v-model="newContactClientId">
+                  <option value="">-- None --</option>
+                  <option v-for="cl in allClients" :key="cl.id" :value="cl.id">{{ cl.name }}</option>
+                </select>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="btn btn-sm btn-primary"
+              :disabled="!newContactFirstName.trim() || creatingContact"
+              @click="addContact"
+            >
+              {{ creatingContact ? 'Adding...' : 'Create & Select' }}
+            </button>
           </div>
         </div>
 
@@ -343,9 +414,10 @@ async function save() {
 .contact-header label { font-size: 0.75rem; font-weight: 600; color: var(--p-text-muted-color); text-transform: uppercase; letter-spacing: 0.05em; }
 .btn-icon { background: none; border: 1px solid var(--p-content-border-color); border-radius: 0.375rem; cursor: pointer; padding: 0.25rem 0.5rem; color: var(--p-text-muted-color); font-size: 0.75rem; }
 .btn-icon:hover { background: var(--p-content-hover-background); }
-.new-contact-form .field-row { grid-template-columns: 1fr 1fr auto; }
+.new-contact-form { display: flex; flex-direction: column; gap: 0.5rem; padding: 0.5rem; border: 1px dashed var(--p-content-border-color); border-radius: 0.375rem; }
+.new-contact-form .field-row { grid-template-columns: 1fr 1fr; }
 .btn { padding: 0.5rem 1rem; border: 1px solid var(--p-content-border-color); border-radius: 0.375rem; background: var(--p-content-background); cursor: pointer; font-size: 0.875rem; margin-left: 0.5rem; color: var(--p-text-color); }
-.btn-sm { padding: 0.5rem 0.75rem; font-size: 0.8rem; margin-left: 0; }
+.btn-sm { padding: 0.5rem 0.75rem; font-size: 0.8rem; margin-left: 0; margin-top: 0.25rem; }
 .btn-primary { background: var(--p-primary-color); color: #fff; border-color: var(--p-primary-color); }
 .btn-primary:hover { background: var(--p-primary-hover-color); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/components/modals/TaskDetailModal.vue
+++ b/frontend/src/components/modals/TaskDetailModal.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, onBeforeUnmount } from 'vue'
 import Dialog from 'primevue/dialog'
-import type { Task, Employee } from '../../types'
-import { getTask, createTask, updateTask, deleteTask, addTaskNote, updateTaskNote, deleteTaskNote, uploadImage } from '../../api/tasks'
+import type { Task, Employee, ProjectSummary } from '../../types'
+import { getTask, createTask, updateTask, deleteTask, addTaskNote, updateTaskNote, deleteTaskNote, uploadImage, getTags, reorderTasks } from '../../api/tasks'
 import { getEmployees } from '../../api/employees'
+import { getProjects } from '../../api/projects'
 import { useToast } from '../../composables/useToast'
 import { useAuth } from '../../composables/useAuth'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
@@ -33,10 +34,20 @@ const noteSaving = ref(false)
 const imageUploading = ref(false)
 const descUploading = ref(false)
 const editingDescription = ref(false)
+const descAutoSaving = ref(false)
+let descSaveTimer: ReturnType<typeof setTimeout> | null = null
 function startEditDescription() {
   editingDescription.value = true
 }
 const showDeleteConfirm = ref(false)
+
+// Create-mode state
+const projects = ref<ProjectSummary[]>([])
+const newProjectId = ref('')
+const isCreateMode = computed(() => !props.taskId)
+const sortedProjects = computed(() =>
+  [...projects.value].sort((a, b) => (a.project_name || '').localeCompare(b.project_name || ''))
+)
 
 // Local form state (buffered until Save)
 const form = ref({
@@ -47,7 +58,13 @@ const form = ref({
   start_date: null as string | null,
   due_date: null as string | null,
   assignee_ids: [] as string[],
+  is_pinned: false,
+  tags: [] as string[],
 })
+const existingTags = ref<string[]>([])
+const newTag = ref('')
+const tagInputVisible = ref(false)
+
 function populateForm(t: Task) {
   form.value = {
     title: t.title,
@@ -57,9 +74,40 @@ function populateForm(t: Task) {
     start_date: t.start_date?.split('T')[0] ?? null,
     due_date: t.due_date?.split('T')[0] ?? null,
     assignee_ids: t.assignees?.map(a => a.id) ?? [],
+    is_pinned: t.is_pinned ?? false,
+    tags: [...(t.tags ?? [])],
   }
   editingDescription.value = false
+  // Track the last saved description so the watcher doesn't fire on populate
+  lastSavedDesc.value = t.description || null
 }
+
+// Auto-save description with debounce
+const lastSavedDesc = ref<string | null>(null)
+watch(() => form.value.description, (newDesc) => {
+  if (!task.value || !editingDescription.value) return
+  if (newDesc === lastSavedDesc.value) return
+  // Clear any pending save
+  if (descSaveTimer) clearTimeout(descSaveTimer)
+  descAutoSaving.value = true
+  descSaveTimer = setTimeout(async () => {
+    if (!task.value) return
+    try {
+      await updateTask(task.value.id, { description: newDesc?.trim() || null })
+      lastSavedDesc.value = newDesc || null
+      emit('saved')
+    } catch (e) {
+      toast.error(String(e))
+    } finally {
+      descAutoSaving.value = false
+    }
+  }, 1500)
+}, { deep: true })
+
+// Clear pending debounce on unmount so it doesn't fire after the modal closes
+onBeforeUnmount(() => {
+  if (descSaveTimer) clearTimeout(descSaveTimer)
+})
 
 function onPriorityChange(event: Event) {
   const val = (event.target as HTMLSelectElement).value
@@ -100,19 +148,45 @@ const sortedNotes = computed(() => {
 })
 
 watch(visible, async (val) => {
-  if (!val || !props.taskId) return
+  if (!val) return
   parentTaskId.value = null
   showDeleteConfirm.value = false
   editingNoteId.value = null
   loading.value = true
   try {
-    const [t, emps] = await Promise.all([
-      getTask(props.taskId),
-      getEmployees(),
-    ])
-    task.value = t
-    employees.value = emps
-    populateForm(t)
+    if (isCreateMode.value) {
+      const [emps, projs, tags] = await Promise.all([
+        getEmployees(),
+        projects.value.length ? Promise.resolve(projects.value) : getProjects(),
+        getTags(),
+      ])
+      employees.value = emps
+      projects.value = projs
+      existingTags.value = tags
+      task.value = null
+      newProjectId.value = props.projectId || ''
+      form.value = {
+        title: '',
+        description: null,
+        status: 'todo',
+        priority: null,
+        start_date: null,
+        due_date: null,
+        assignee_ids: user.value ? [user.value.id] : [],
+        is_pinned: false,
+        tags: [],
+      }
+    } else {
+      const [t, emps, tags] = await Promise.all([
+        getTask(props.taskId!),
+        getEmployees(),
+        getTags(),
+      ])
+      task.value = t
+      employees.value = emps
+      existingTags.value = tags
+      populateForm(t)
+    }
   } catch (e) {
     toast.error(String(e))
     visible.value = false
@@ -122,23 +196,43 @@ watch(visible, async (val) => {
 })
 
 async function saveAll() {
-  if (!task.value) return
   if (!form.value.title.trim()) {
     toast.error('Task title is required')
     return
   }
+  if (isCreateMode.value && !newProjectId.value) {
+    toast.error('Project is required')
+    return
+  }
   saving.value = true
   try {
-    task.value = await updateTask(task.value.id, {
-      title: form.value.title.trim(),
-      description: form.value.description?.trim() || null,
-      status: form.value.status,
-      priority: form.value.priority,
-      start_date: form.value.start_date || null,
-      due_date: form.value.due_date || null,
-      assignee_ids: form.value.assignee_ids,
-    })
-    populateForm(task.value)
+    if (isCreateMode.value) {
+      await createTask(newProjectId.value, {
+        title: form.value.title.trim(),
+        description: form.value.description?.trim() || null,
+        status: form.value.status,
+        priority: form.value.priority,
+        start_date: form.value.start_date || null,
+        due_date: form.value.due_date || null,
+        assignee_ids: form.value.assignee_ids,
+        is_pinned: form.value.is_pinned,
+        tags: form.value.tags,
+      })
+    } else {
+      if (!task.value) return
+      task.value = await updateTask(task.value.id, {
+        title: form.value.title.trim(),
+        description: form.value.description?.trim() || null,
+        status: form.value.status,
+        priority: form.value.priority,
+        start_date: form.value.start_date || null,
+        due_date: form.value.due_date || null,
+        assignee_ids: form.value.assignee_ids,
+        is_pinned: form.value.is_pinned,
+        tags: form.value.tags,
+      })
+      populateForm(task.value)
+    }
     emit('saved')
     visible.value = false
   } catch (e) {
@@ -187,6 +281,29 @@ function toggleAssignee(empId: string) {
   }
 
 }
+
+function togglePin() {
+  form.value.is_pinned = !form.value.is_pinned
+}
+
+function addTag() {
+  const tag = newTag.value.trim().toLowerCase()
+  if (!tag) return
+  if (!form.value.tags.includes(tag)) {
+    form.value.tags = [...form.value.tags, tag]
+  }
+  newTag.value = ''
+  tagInputVisible.value = false
+}
+
+function removeTag(tag: string) {
+  form.value.tags = form.value.tags.filter(t => t !== tag)
+}
+
+// Suggested tags: existing tags not already on the task
+const suggestedTags = computed(() =>
+  existingTags.value.filter(t => !form.value.tags.includes(t))
+)
 
 async function submitNote() {
   if (!newNote.value.trim() || !task.value) return
@@ -252,6 +369,65 @@ async function removeSubtask(subId: string) {
   } catch (e) {
     toast.error(String(e))
   }
+}
+
+// Subtask drag-and-drop reordering
+const draggingSubId = ref<string | null>(null)
+const dragOverSubId = ref<string | null>(null)
+
+function onSubtaskDragStart(subId: string, event: DragEvent) {
+  draggingSubId.value = subId
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', subId)
+  }
+}
+
+function onSubtaskDragOver(subId: string, event: DragEvent) {
+  event.preventDefault()
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+  dragOverSubId.value = subId
+}
+
+function onSubtaskDragLeave() {
+  dragOverSubId.value = null
+}
+
+async function onSubtaskDrop(targetId: string, event: DragEvent) {
+  event.preventDefault()
+  const sourceId = draggingSubId.value
+  draggingSubId.value = null
+  dragOverSubId.value = null
+  if (!sourceId || sourceId === targetId || !task.value?.subtasks) return
+
+  const subs = [...task.value.subtasks]
+  const fromIdx = subs.findIndex(s => s.id === sourceId)
+  const toIdx = subs.findIndex(s => s.id === targetId)
+  if (fromIdx === -1 || toIdx === -1) return
+
+  // Reorder locally
+  const [moved] = subs.splice(fromIdx, 1)
+  if (!moved) return
+  subs.splice(toIdx, 0, moved)
+
+  // Optimistically update local state
+  task.value.subtasks = subs.map((s, i) => ({ ...s, sort_order: i + 1 }))
+
+  // Persist sort_order updates in a single request
+  const items = subs.map((s, i) => ({ task_id: s.id, sort_order: i + 1 }))
+  try {
+    await reorderTasks(items)
+    emit('saved')
+  } catch (e) {
+    toast.error(String(e))
+    // Reload on failure
+    if (task.value) task.value = await getTask(task.value.id)
+  }
+}
+
+function onSubtaskDragEnd() {
+  draggingSubId.value = null
+  dragOverSubId.value = null
 }
 
 async function openSubtask(id: string) {
@@ -349,11 +525,22 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
     </template>
 
     <div v-if="loading" class="loading">Loading...</div>
-    <div v-else-if="task" class="task-detail">
+    <div v-else-if="task || isCreateMode" class="task-detail">
       <!-- Back to parent -->
       <button v-if="parentTaskId" class="btn btn-sm" @click="goBackToParent">
         <i class="pi pi-arrow-left" /> Back to parent task
       </button>
+
+      <!-- Project selector (create mode only) -->
+      <div v-if="isCreateMode" class="field">
+        <label>Project</label>
+        <select v-model="newProjectId">
+          <option value="" disabled>Select project...</option>
+          <option v-for="p in sortedProjects" :key="p.id" :value="p.id">
+            {{ p.project_name }}{{ p.job_code ? ` (${p.job_code})` : '' }}
+          </option>
+        </select>
+      </div>
 
       <!-- Status & Priority -->
       <div class="field-group">
@@ -368,6 +555,50 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
           <select :value="form.priority ?? ''" @change="onPriorityChange($event)">
             <option v-for="opt in priorityOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
+        </div>
+      </div>
+
+      <!-- Pin & Tags -->
+      <div class="field-group">
+        <div class="field">
+          <label>Pin</label>
+          <button
+            class="pin-toggle"
+            :class="{ active: form.is_pinned }"
+            @click="togglePin"
+          >
+            <i class="pi" :class="form.is_pinned ? 'pi-bookmark-fill' : 'pi-bookmark'" />
+            {{ form.is_pinned ? 'Pinned to top' : 'Pin to top' }}
+          </button>
+        </div>
+        <div class="field">
+          <label>Tags</label>
+          <div class="tag-editor">
+            <span v-for="tag in form.tags" :key="tag" class="tag-chip">
+              {{ tag }}
+              <button class="tag-remove" @click="removeTag(tag)">&times;</button>
+            </span>
+            <button
+              v-if="!tagInputVisible"
+              class="tag-add-btn"
+              @click="tagInputVisible = true"
+            >
+              <i class="pi pi-plus" /> Add tag
+            </button>
+            <input
+              v-else
+              v-model="newTag"
+              type="text"
+              class="tag-input"
+              placeholder="Tag name..."
+              list="tag-suggestions"
+              @keydown.enter="addTag"
+              @blur="addTag"
+            />
+            <datalist id="tag-suggestions">
+              <option v-for="tag in suggestedTags" :key="tag" :value="tag" />
+            </datalist>
+          </div>
         </div>
       </div>
 
@@ -409,6 +640,7 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
       <div class="field">
         <div class="desc-header">
           <label>Description</label>
+          <small v-if="descAutoSaving" class="auto-save-indicator">Saving…</small>
           <button
             v-if="!editingDescription && form.description"
             class="btn-edit-inline"
@@ -426,7 +658,7 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
       </div>
 
       <!-- Subtasks -->
-      <div v-if="!task.parent_id" class="section">
+      <div v-if="!isCreateMode && task && !task.parent_id" class="section">
         <div class="section-header">
           <label>Subtasks</label>
           <button class="btn-icon" :title="showSubtaskForm ? 'Cancel' : 'Add subtask'" @click="showSubtaskForm = !showSubtaskForm">
@@ -444,7 +676,15 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
             v-for="sub in task.subtasks"
             :key="sub.id"
             class="subtask-item"
+            :class="{ 'dragging': draggingSubId === sub.id, 'drag-over': dragOverSubId === sub.id }"
+            draggable="true"
+            @dragstart="onSubtaskDragStart(sub.id, $event)"
+            @dragover="onSubtaskDragOver(sub.id, $event)"
+            @dragleave="onSubtaskDragLeave"
+            @drop="onSubtaskDrop(sub.id, $event)"
+            @dragend="onSubtaskDragEnd"
           >
+            <i class="pi pi-bars subtask-grip" title="Drag to reorder" />
             <i class="pi" :class="sub.status === 'done' ? 'pi-check-circle' : 'pi-circle'" @click="openSubtask(sub.id)" />
             <span class="subtask-title" @click="openSubtask(sub.id)">{{ sub.title }}</span>
             <span class="subtask-status">{{ sub.status.replace('_', ' ') }}</span>
@@ -455,7 +695,7 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
       </div>
 
       <!-- Notes -->
-      <div class="section">
+      <div v-if="!isCreateMode" class="section">
         <label>Notes</label>
         <div class="add-note">
           <MarkdownEditor v-model="newNote" :rows="3" placeholder="Add a note..." @paste="handleNotePaste" />
@@ -485,7 +725,7 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
       </div>
 
       <!-- Delete -->
-      <div class="delete-section">
+      <div v-if="!isCreateMode" class="delete-section">
         <button v-if="!showDeleteConfirm" class="btn btn-danger btn-sm" @click="showDeleteConfirm = true">
           <i class="pi pi-trash" /> Delete Task
         </button>
@@ -521,6 +761,7 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
 .btn-edit-inline { background: none; border: none; color: var(--p-text-muted-color); cursor: pointer; font-size: 0.75rem; padding: 0.125rem 0.25rem; }
 .btn-edit-inline:hover { color: var(--p-primary-color); }
 .btn-edit-inline .pi { font-size: 0.6875rem; }
+.auto-save-indicator { color: var(--p-primary-color); font-size: 0.6875rem; font-style: italic; margin-left: 0.5rem; }
 
 .assignee-chips { display: flex; flex-wrap: wrap; gap: 0.375rem; }
 .chip { padding: 0.25rem 0.625rem; border: 1px solid var(--p-content-border-color); border-radius: 9999px; font-size: 0.75rem; cursor: pointer; background: var(--p-content-background); color: var(--p-text-muted-color); transition: all 0.15s; }
@@ -535,8 +776,11 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
 .subtask-form { display: flex; gap: 0.375rem; align-items: center; margin-bottom: 0.5rem; }
 .subtask-input { flex: 1; padding: 0.375rem 0.5rem; border: 1px solid var(--p-form-field-border-color); border-radius: 0.375rem; font-size: 0.8125rem; background: var(--p-form-field-background); color: var(--p-text-color); }
 .subtask-list { display: flex; flex-direction: column; gap: 0.25rem; }
-.subtask-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.375rem 0.5rem; font-size: 0.8125rem; border: 1px solid var(--p-content-border-color); border-radius: 0.375rem; transition: background 0.15s; }
+.subtask-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.375rem 0.5rem; font-size: 0.8125rem; border: 1px solid var(--p-content-border-color); border-radius: 0.375rem; transition: background 0.15s, border-color 0.15s, opacity 0.15s; cursor: grab; }
 .subtask-item:hover { background: var(--p-content-hover-background); }
+.subtask-item.dragging { opacity: 0.4; cursor: grabbing; }
+.subtask-item.drag-over { border-color: var(--p-primary-color); border-top: 2px solid var(--p-primary-color); }
+.subtask-grip { font-size: 0.75rem; color: var(--p-text-muted-color); cursor: grab; }
 .subtask-item .pi { font-size: 0.75rem; color: var(--p-text-muted-color); cursor: pointer; }
 .subtask-title { flex: 1; cursor: pointer; }
 .subtask-status { font-size: 0.6875rem; text-transform: uppercase; color: var(--p-text-muted-color); }
@@ -575,4 +819,68 @@ async function handleDescriptionPaste(event: ClipboardEvent) {
 .upload-indicator { color: var(--p-primary-color); font-size: 0.75rem; font-style: italic; }
 
 .modal-footer { display: flex; justify-content: flex-end; gap: 0.5rem; }
+
+.pin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  transition: all 0.15s;
+}
+.pin-toggle:hover { border-color: var(--p-primary-color); color: var(--p-text-color); }
+.pin-toggle.active { background: var(--p-primary-color); color: #fff; border-color: var(--p-primary-color); }
+.pin-toggle .pi { font-size: 0.75rem; }
+
+.tag-editor { display: flex; flex-wrap: wrap; gap: 0.375rem; align-items: center; }
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.5rem;
+  background: var(--p-content-hover-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  color: var(--p-text-color);
+}
+.tag-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--p-text-muted-color);
+  font-size: 0.875rem;
+  padding: 0 0.125rem;
+  line-height: 1;
+}
+.tag-remove:hover { color: var(--p-red-600); }
+.tag-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.5rem;
+  border: 1px dashed var(--p-content-border-color);
+  border-radius: 9999px;
+  background: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+}
+.tag-add-btn:hover { border-color: var(--p-primary-color); color: var(--p-primary-color); }
+.tag-add-btn .pi { font-size: 0.625rem; }
+.tag-input {
+  padding: 0.1875rem 0.5rem;
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  background: var(--p-form-field-background);
+  color: var(--p-text-color);
+  width: 120px;
+}
+.tag-input:focus { outline: none; border-color: var(--p-primary-color); }
 </style>

--- a/frontend/src/components/project/ProjectTeam.vue
+++ b/frontend/src/components/project/ProjectTeam.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import type { ProjectSummary, ProjectContact, Contact } from '../../types'
+import type { ProjectSummary, ProjectContact, Contact, Client } from '../../types'
 import { getProjectContacts, addProjectContact, removeProjectContact } from '../../api/projects'
 import { getContacts, createContact } from '../../api/contacts'
+import { getClients } from '../../api/clients'
 import { useToast } from '../../composables/useToast'
 
 const props = defineProps<{
@@ -15,14 +16,20 @@ const teamContacts = ref<ProjectContact[]>([])
 const teamLoading = ref(false)
 const showAddContact = ref(false)
 const allContacts = ref<Contact[]>([])
+const allClients = ref<Client[]>([])
 const addContactId = ref('')
 const addContactRole = ref('')
 const addContactSaving = ref(false)
 const showNewContactInline = ref(false)
-const newContactName = ref('')
-const newContactEmail = ref('')
-const newContactRole = ref('')
 const creatingNewContact = ref(false)
+
+// New contact form fields
+const newContactFirstName = ref('')
+const newContactLastName = ref('')
+const newContactEmail = ref('')
+const newContactPhone = ref('')
+const newContactRole = ref('')
+const newContactClientId = ref('')
 
 const ROLE_SUGGESTIONS = [
   'Project Manager',
@@ -36,9 +43,50 @@ const ROLE_SUGGESTIONS = [
   'Reviewer',
 ]
 
-const availableContacts = computed(() => {
+// Contacts from the project's company, sorted by name
+const projectCompanyContacts = computed(() => {
   const linked = new Set(teamContacts.value.map(c => c.contact_id))
-  return allContacts.value.filter(c => !linked.has(c.id))
+  const clientId = props.project.client_id
+  return allContacts.value
+    .filter(c => c.client_id === clientId && !linked.has(c.id))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+// Contacts from other companies, sorted by company then name
+const otherContacts = computed(() => {
+  const linked = new Set(teamContacts.value.map(c => c.contact_id))
+  const clientId = props.project.client_id
+  return allContacts.value
+    .filter(c => c.client_id !== clientId && !linked.has(c.id))
+    .sort((a, b) => {
+      const aClient = allClients.value.find(cl => cl.id === a.client_id)
+      const bClient = allClients.value.find(cl => cl.id === b.client_id)
+      const aCompany = aClient?.name ?? 'No Company'
+      const bCompany = bClient?.name ?? 'No Company'
+      if (aCompany !== bCompany) return aCompany.localeCompare(bCompany)
+      return a.name.localeCompare(b.name)
+    })
+})
+
+// Grouped other contacts by company name for optgroup rendering
+const otherContactsGrouped = computed(() => {
+  const groups: { companyName: string; contacts: Contact[] }[] = []
+  for (const c of otherContacts.value) {
+    const client = allClients.value.find(cl => cl.id === c.client_id)
+    const companyName = client?.name ?? 'No Company'
+    let group = groups.find(g => g.companyName === companyName)
+    if (!group) {
+      group = { companyName, contacts: [] }
+      groups.push(group)
+    }
+    group.contacts.push(c)
+  }
+  return groups
+})
+
+const projectCompanyName = computed(() => {
+  const client = allClients.value.find(cl => cl.id === props.project.client_id)
+  return client?.name ?? 'Project Company'
 })
 
 watch(() => props.project.id, async () => {
@@ -61,8 +109,15 @@ async function openAddContact() {
   addContactId.value = ''
   addContactRole.value = ''
   showNewContactInline.value = false
+  // Default the new contact's company to the project's company
+  newContactClientId.value = props.project.client_id || ''
   try {
-    allContacts.value = await getContacts(props.project.client_id || undefined)
+    const [contacts, clients] = await Promise.all([
+      getContacts(),  // no filter — load ALL contacts
+      getClients(),
+    ])
+    allContacts.value = contacts
+    allClients.value = clients
   } catch (e) {
     console.error('Failed to load contacts:', e)
   }
@@ -87,14 +142,18 @@ async function submitAddContact() {
 }
 
 async function submitNewTeamContact() {
-  if (!newContactName.value.trim()) return
+  const firstName = newContactFirstName.value.trim()
+  const lastName = newContactLastName.value.trim()
+  if (!firstName) return
   creatingNewContact.value = true
   try {
+    const fullName = [firstName, lastName].filter(Boolean).join(' ')
     const contact = await createContact({
-      name: newContactName.value.trim(),
+      name: fullName,
       email: newContactEmail.value.trim() || undefined,
+      phone: newContactPhone.value.trim() || undefined,
       role: newContactRole.value || undefined,
-      client_id: props.project.client_id || undefined,
+      client_id: newContactClientId.value || undefined,
     })
     await addProjectContact(props.project.id, {
       contact_id: contact.id,
@@ -102,9 +161,12 @@ async function submitNewTeamContact() {
     })
     showNewContactInline.value = false
     showAddContact.value = false
-    newContactName.value = ''
+    newContactFirstName.value = ''
+    newContactLastName.value = ''
     newContactEmail.value = ''
+    newContactPhone.value = ''
     newContactRole.value = ''
+    newContactClientId.value = ''
     toast.success('Contact created and added to team')
     await loadTeam()
   } catch (e) {
@@ -112,6 +174,15 @@ async function submitNewTeamContact() {
   } finally {
     creatingNewContact.value = false
   }
+}
+
+function resetNewContactForm() {
+  newContactFirstName.value = ''
+  newContactLastName.value = ''
+  newContactEmail.value = ''
+  newContactPhone.value = ''
+  newContactRole.value = ''
+  newContactClientId.value = props.project.client_id || ''
 }
 
 async function removeTeamContact(contactId: string) {
@@ -138,12 +209,20 @@ defineExpose({ teamCount: computed(() => teamContacts.value.length) })
 
     <!-- Add contact form -->
     <div v-if="showAddContact" class="add-contact-form">
+      <!-- Select existing contact -->
       <div class="add-contact-row">
         <select v-model="addContactId" class="contact-select">
           <option value="">-- Select contact --</option>
-          <option v-for="c in availableContacts" :key="c.id" :value="c.id">
-            {{ c.name }}{{ c.email ? ` (${c.email})` : '' }}
-          </option>
+          <optgroup v-if="projectCompanyContacts.length" :label="projectCompanyName">
+            <option v-for="c in projectCompanyContacts" :key="c.id" :value="c.id">
+              {{ c.name }}{{ c.email ? ` — ${c.email}` : '' }}
+            </option>
+          </optgroup>
+          <optgroup v-for="group in otherContactsGrouped" :key="group.companyName" :label="group.companyName">
+            <option v-for="c in group.contacts" :key="c.id" :value="c.id">
+              {{ c.name }}{{ c.email ? ` — ${c.email}` : '' }}
+            </option>
+          </optgroup>
         </select>
         <select v-model="addContactRole" class="role-select">
           <option value="">-- Role --</option>
@@ -153,20 +232,39 @@ defineExpose({ teamCount: computed(() => teamContacts.value.length) })
           Add
         </button>
       </div>
+
+      <div class="new-contact-divider">
+        <span>or</span>
+      </div>
+
       <div class="new-contact-toggle">
-        <button class="btn-link" @click="showNewContactInline = !showNewContactInline">
-          {{ showNewContactInline ? 'Cancel' : '+ New contact' }}
+        <button class="btn-link" @click="showNewContactInline = !showNewContactInline; resetNewContactForm()">
+          {{ showNewContactInline ? 'Cancel new contact' : '+ Add new contact' }}
         </button>
       </div>
-      <div v-if="showNewContactInline" class="add-contact-row">
-        <input v-model="newContactName" type="text" placeholder="Name" class="contact-input" />
-        <input v-model="newContactEmail" type="email" placeholder="Email" class="contact-input" />
-        <select v-model="newContactRole" class="role-select">
-          <option value="">-- Role --</option>
-          <option v-for="r in ROLE_SUGGESTIONS" :key="r" :value="r">{{ r }}</option>
-        </select>
-        <button class="btn btn-sm btn-primary" :disabled="!newContactName.trim() || creatingNewContact" @click="submitNewTeamContact">
-          Create & Add
+
+      <!-- New contact form -->
+      <div v-if="showNewContactInline" class="new-contact-form">
+        <div class="new-contact-row">
+          <input v-model="newContactFirstName" type="text" placeholder="First name" class="contact-input" />
+          <input v-model="newContactLastName" type="text" placeholder="Last name" class="contact-input" />
+        </div>
+        <div class="new-contact-row">
+          <input v-model="newContactEmail" type="email" placeholder="Email" class="contact-input" />
+          <input v-model="newContactPhone" type="tel" placeholder="Phone" class="contact-input" />
+        </div>
+        <div class="new-contact-row">
+          <select v-model="newContactClientId" class="company-select">
+            <option value="">-- Affiliated company --</option>
+            <option v-for="cl in allClients" :key="cl.id" :value="cl.id">{{ cl.name }}</option>
+          </select>
+          <select v-model="newContactRole" class="role-select">
+            <option value="">-- Role --</option>
+            <option v-for="r in ROLE_SUGGESTIONS" :key="r" :value="r">{{ r }}</option>
+          </select>
+        </div>
+        <button class="btn btn-sm btn-primary" :disabled="!newContactFirstName.trim() || creatingNewContact" @click="submitNewTeamContact">
+          {{ creatingNewContact ? 'Creating...' : 'Create & Add' }}
         </button>
       </div>
     </div>
@@ -357,7 +455,8 @@ defineExpose({ teamCount: computed(() => teamContacts.value.length) })
 
 .contact-select,
 .role-select,
-.contact-input {
+.contact-input,
+.company-select {
   padding: 0.375rem 0.5rem;
   border: 1px solid var(--p-form-field-border-color);
   border-radius: 0.375rem;
@@ -366,9 +465,30 @@ defineExpose({ teamCount: computed(() => teamContacts.value.length) })
   color: var(--p-text-color);
 }
 
-.contact-select { flex: 2; min-width: 0; }
-.role-select { flex: 1; min-width: 0; }
-.contact-input { flex: 1; min-width: 0; }
+.contact-select { flex: 2; min-width: 200px; }
+.role-select { flex: 1; min-width: 120px; }
+.contact-input { flex: 1; min-width: 120px; }
+.company-select { flex: 2; min-width: 180px; }
+
+.new-contact-divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+  margin: 0.25rem 0;
+}
+
+.new-contact-divider::before,
+.new-contact-divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--p-content-border-color);
+}
+
+.new-contact-divider span {
+  padding: 0 0.5rem;
+}
 
 .new-contact-toggle {
   display: flex;
@@ -385,5 +505,20 @@ defineExpose({ teamCount: computed(() => teamContacts.value.length) })
 
 .btn-link:hover {
   text-decoration: underline;
+}
+
+.new-contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px dashed var(--p-content-border-color);
+  border-radius: 0.375rem;
+}
+
+.new-contact-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 </style>

--- a/frontend/src/composables/useEnvironment.ts
+++ b/frontend/src/composables/useEnvironment.ts
@@ -1,0 +1,10 @@
+import { computed } from 'vue'
+
+const isTestServer = computed(() => {
+  if (typeof window === 'undefined') return false
+  return window.location.port === '3001'
+})
+
+export function useEnvironment() {
+  return { isTestServer }
+}

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -3,11 +3,13 @@ import { ref, onMounted } from 'vue'
 import Toast from 'primevue/toast'
 import { useColorMode } from '../composables/useColorMode'
 import { useAuth } from '../composables/useAuth'
+import { useEnvironment } from '../composables/useEnvironment'
 import { getCompanySettings } from '../api/company'
 
 const sidebarCollapsed = ref(false)
 const { isDark, toggleColorMode } = useColorMode()
 const { user, logout } = useAuth()
+const { isTestServer } = useEnvironment()
 const showUserMenu = ref(false)
 const companyName = ref('')
 
@@ -44,7 +46,10 @@ function handleLogout() {
 
 <template>
   <Toast />
-  <div class="layout">
+  <div v-if="isTestServer" class="test-banner">
+    ⚠️ TEST SERVER — not production
+  </div>
+  <div class="layout" :class="{ 'test-mode': isTestServer }">
     <aside class="sidebar" :class="{ collapsed: sidebarCollapsed }">
       <div class="sidebar-header">
         <div v-if="!sidebarCollapsed" class="sidebar-brand">
@@ -316,5 +321,27 @@ function handleLogout() {
 
 .sidebar.collapsed + .main-content {
   margin-left: 60px;
+}
+
+/* Test server banner */
+.test-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: #f59e0b;
+  color: #1a1a1a;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.25rem 0;
+  letter-spacing: 0.05em;
+}
+.layout.test-mode {
+  padding-top: 1.5rem;
+}
+.layout.test-mode .sidebar {
+  border-left: 3px solid #f59e0b;
 }
 </style>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -251,6 +251,8 @@ export interface TaskCreatePayload {
   start_date?: string | null
   due_date?: string | null
   assignee_ids?: string[]
+  is_pinned?: boolean
+  tags?: string[]
 }
 
 export interface TaskUpdatePayload {
@@ -261,6 +263,9 @@ export interface TaskUpdatePayload {
   start_date?: string | null
   due_date?: string | null
   assignee_ids?: string[]
+  is_pinned?: boolean
+  tags?: string[]
+  sort_order?: number
 }
 
 export interface TaskAssignee {
@@ -285,6 +290,8 @@ export interface Task {
   created_at: string | null
   updated_at: string | null
   is_stale?: boolean
+  is_pinned?: boolean
+  tags?: string[]
   assignees?: TaskAssignee[]
   notes?: TaskNote[]
   subtasks?: Task[]

--- a/frontend/src/views/FinancialView.vue
+++ b/frontend/src/views/FinancialView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { useInvoices } from '../composables/useInvoices'
 import { useToast } from '../composables/useToast'
 import InvoiceEditModal from '../components/modals/InvoiceEditModal.vue'
@@ -7,6 +8,7 @@ import InvoiceActionsModal from '../components/modals/InvoiceActionsModal.vue'
 import { formatDate as formatDateUtil, daysPastDue } from '../utils/dates'
 
 const toast = useToast()
+const router = useRouter()
 const {
   loading,
   searchQuery,
@@ -67,6 +69,10 @@ function formatDate(dateStr: string | null): string {
 function openEdit(invoiceId: string) {
   editingInvoiceId.value = invoiceId
   showEditModal.value = true
+}
+
+function goToProject(projectId: string) {
+  router.push(`/projects/${projectId}`)
 }
 
 function openActions(invoiceId: string) {
@@ -306,7 +312,14 @@ async function doBatchMarkPaid() {
             />
           </td>
           <td class="cell-name">{{ inv.invoice_number }}</td>
-          <td>{{ inv.project_name }}</td>
+          <td class="cell-project">
+            <a
+              v-if="inv.project_id"
+              class="project-link"
+              @click.stop="goToProject(inv.project_id)"
+            >{{ inv.project_name }}</a>
+            <span v-else>{{ inv.project_name }}</span>
+          </td>
           <td>{{ inv.client_name || '' }}</td>
           <td>{{ inv.pm_name || '' }}</td>
           <td>{{ formatDate(inv.invoice_date || inv.sent_at || inv.created_at) }}</td>
@@ -595,6 +608,15 @@ async function doBatchMarkPaid() {
 }
 
 .cell-name { font-weight: 500; }
+
+.cell-project .project-link {
+  color: var(--p-primary-color);
+  cursor: pointer;
+  text-decoration: none;
+}
+.cell-project .project-link:hover {
+  text-decoration: underline;
+}
 
 .row-clickable { cursor: pointer; }
 .row-clickable:hover td { background: var(--p-content-hover-background); }

--- a/frontend/src/views/MyTasksView.vue
+++ b/frontend/src/views/MyTasksView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { MyTask, Task, ProjectSummary } from '../types'
-import { getMyTasks, getDoneToday, createTask, updateTask } from '../api/tasks'
+import type { MyTask, Task, ProjectSummary, Employee } from '../types'
+import { getMyTasks, getDoneToday, createTask, updateTask, getTags, bulkUpdateTasks, bulkDeleteTasks, reorderTasks } from '../api/tasks'
+import type { BulkPatchFields } from '../api/tasks'
 import { getProjects } from '../api/projects'
+import { getEmployees } from '../api/employees'
 import { useAuth } from '../composables/useAuth'
 import { useToast } from '../composables/useToast'
 import TaskDetailModal from '../components/modals/TaskDetailModal.vue'
@@ -45,8 +47,31 @@ const showQuickAdd = ref(false)
 const quickAddTitle = ref('')
 const quickAddProjectId = ref('')
 const quickAddDueDate = ref(todayStr())
+const quickAddPriority = ref<number | null>(null)
+const quickAddTags = ref('')
 const quickAddSubmitting = ref(false)
 const projects = ref<ProjectSummary[]>([])
+const sortedProjects = computed(() =>
+  [...projects.value].sort((a, b) =>
+    (a.project_name || '').localeCompare(b.project_name || ''),
+  ),
+)
+const employees = ref<Employee[]>([])
+const allTags = ref<string[]>([])
+
+// Sort mode: 'due_date' (default), 'project', 'assignee', 'tags', 'priority', 'manual'
+type SortMode = 'due_date' | 'project' | 'assignee' | 'tags' | 'priority' | 'manual'
+const sortMode = ref<SortMode>('due_date')
+
+// Assignee filter: 'me' (self), 'everyone' (all), or specific employee IDs
+type AssigneeFilter = 'me' | 'everyone' | 'custom'
+const assigneeFilter = ref<AssigneeFilter>('me')
+const selectedAssigneeIds = ref<Set<string>>(new Set())
+const assigneeFilterOpen = ref(false)
+
+// Tag filter
+const selectedTagIds = ref<Set<string>>(new Set())
+const tagFilterOpen = ref(false)
 
 const activeTasks = computed(() =>
   tasks.value.filter(t => t.status !== 'done' && t.status !== 'canceled')
@@ -96,7 +121,36 @@ const upNextTasks = computed(() => {
 })
 
 function sortForUpNext(list: MyTask[]): MyTask[] {
-  return [...list].sort((a, b) => {
+  const sorted = [...list]
+  // Always pin first
+  sorted.sort((a, b) => {
+    const aPin = a.is_pinned ? 1 : 0
+    const bPin = b.is_pinned ? 1 : 0
+    if (aPin !== bPin) return bPin - aPin
+
+    if (sortMode.value === 'project') {
+      const aP = a.project_name ?? ''
+      const bP = b.project_name ?? ''
+      if (aP !== bP) return aP.localeCompare(bP)
+    } else if (sortMode.value === 'assignee') {
+      const aA = (a.assignees || []).map(e => e.last_name).join(', ')
+      const bA = (b.assignees || []).map(e => e.last_name).join(', ')
+      if (aA !== bA) return aA.localeCompare(bA)
+    } else if (sortMode.value === 'tags') {
+      const aT = (a.tags || []).join(', ')
+      const bT = (b.tags || []).join(', ')
+      if (aT !== bT) return aT.localeCompare(bT)
+    } else if (sortMode.value === 'priority') {
+      const aPri = a.priority ?? 0
+      const bPri = b.priority ?? 0
+      if (aPri !== bPri) return bPri - aPri
+    } else if (sortMode.value === 'manual') {
+      const aSort = a.sort_order ?? 9999
+      const bSort = b.sort_order ?? 9999
+      if (aSort !== bSort) return aSort - bSort
+    }
+
+    // Default: due date, then priority, then created
     const aDue = a.due_date ?? '9999-12-31'
     const bDue = b.due_date ?? '9999-12-31'
     if (aDue !== bDue) return aDue.localeCompare(bDue)
@@ -105,6 +159,7 @@ function sortForUpNext(list: MyTask[]): MyTask[] {
     if (aPri !== bPri) return bPri - aPri
     return (a.created_at ?? '').localeCompare(b.created_at ?? '')
   })
+  return sorted
 }
 
 // The main "Up Next" section content varies by active filter
@@ -208,8 +263,24 @@ async function loadAll() {
   if (!user.value) return
   loading.value = true
   try {
+    // Determine which assignee IDs to filter by
+    let assigneeIds: string[] | undefined
+    if (assigneeFilter.value === 'me') {
+      assigneeIds = [user.value.id]
+    } else if (assigneeFilter.value === 'everyone') {
+      assigneeIds = employees.value.map(e => e.id)
+    } else if (assigneeFilter.value === 'custom' && selectedAssigneeIds.value.size > 0) {
+      assigneeIds = [...selectedAssigneeIds.value]
+    }
+
+    // Determine tag filter
+    const tagFilter = selectedTagIds.value.size > 0 ? [...selectedTagIds.value] : undefined
+
     const [all, today] = await Promise.all([
-      getMyTasks(user.value.id),
+      getMyTasks(user.value.id, {
+        assignee_ids: assigneeIds,
+        tags: tagFilter,
+      }),
       getDoneToday(user.value.id, todayValue.value),
     ])
     tasks.value = all
@@ -332,6 +403,12 @@ function openQuickAdd() {
   if (!projects.value.length) loadProjects()
 }
 
+function openAddTask() {
+  selectedTaskId.value = null
+  selectedProjectId.value = ''
+  taskModalVisible.value = true
+}
+
 async function submitQuickAdd() {
   if (!quickAddTitle.value.trim() || !quickAddProjectId.value) return
   quickAddSubmitting.value = true
@@ -339,10 +416,16 @@ async function submitQuickAdd() {
     await createTask(quickAddProjectId.value, {
       title: quickAddTitle.value.trim(),
       due_date: quickAddDueDate.value || undefined,
+      priority: quickAddPriority.value || undefined,
+      tags: quickAddTags.value.trim()
+        ? quickAddTags.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean)
+        : undefined,
       assignee_ids: user.value ? [user.value.id] : undefined,
     })
     quickAddTitle.value = ''
     quickAddDueDate.value = todayStr()
+    quickAddPriority.value = null
+    quickAddTags.value = ''
     showQuickAdd.value = false
     await loadAll()
     toast.success('Task created')
@@ -357,6 +440,265 @@ async function submitQuickAdd() {
 function openProjectFilter() {
   projectFilterOpen.value = !projectFilterOpen.value
   if (projectFilterOpen.value && !projects.value.length) loadProjects()
+}
+
+// Assignee filter
+function setAssigneeFilter(mode: AssigneeFilter) {
+  assigneeFilter.value = mode
+  selectedAssigneeIds.value.clear()
+  assigneeFilterOpen.value = false
+  loadAll()
+}
+
+function toggleAssigneeFilter(empId: string) {
+  if (selectedAssigneeIds.value.has(empId)) {
+    selectedAssigneeIds.value.delete(empId)
+  } else {
+    selectedAssigneeIds.value.add(empId)
+  }
+  if (selectedAssigneeIds.value.size > 0) {
+    assigneeFilter.value = 'custom'
+  } else if (assigneeFilter.value === 'custom') {
+    // No one selected — fall back to "me" so the list isn't empty
+    assigneeFilter.value = 'me'
+  }
+  loadAll()
+}
+
+const assigneeFilterLabel = computed(() => {
+  if (assigneeFilter.value === 'me') return 'Just me'
+  if (assigneeFilter.value === 'everyone') return 'Everyone'
+  if (selectedAssigneeIds.value.size > 0) return `${selectedAssigneeIds.value.size} people`
+  return 'Custom'
+})
+
+// Tag filter
+function toggleTagFilter(tag: string) {
+  if (selectedTagIds.value.has(tag)) {
+    selectedTagIds.value.delete(tag)
+  } else {
+    selectedTagIds.value.add(tag)
+  }
+  loadAll()
+}
+
+function clearTagFilter() {
+  selectedTagIds.value.clear()
+  loadAll()
+}
+
+// Pin toggle from row
+async function togglePin(task: MyTask | Task, event: Event) {
+  event.stopPropagation()
+  try {
+    await updateTask(task.id, { is_pinned: !task.is_pinned })
+    await loadAll()
+  } catch (e) {
+    toast.error(String(e))
+  }
+}
+
+// Manual reordering — drag and up/down buttons
+const draggingTaskId = ref<string | null>(null)
+const dragOverTaskId = ref<string | null>(null)
+
+async function moveTask(sourceId: string, targetId: string) {
+  const list = sectionTasks.value
+  const fromIdx = list.findIndex(t => t.id === sourceId)
+  const toIdx = list.findIndex(t => t.id === targetId)
+  if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return
+
+  // Reorder
+  const reordered = [...list]
+  const [moved] = reordered.splice(fromIdx, 1)
+  if (!moved) return
+  reordered.splice(toIdx, 0, moved)
+
+  // Persist new sort_order for all affected tasks in a single request
+  const items = reordered.map((t, i) => ({ task_id: t.id, sort_order: i + 1 }))
+  try {
+    await reorderTasks(items)
+    await loadAll()
+  } catch (e) {
+    toast.error(String(e))
+  }
+}
+
+function onTaskDragStart(taskId: string, event: DragEvent) {
+  draggingTaskId.value = taskId
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', taskId)
+  }
+}
+
+function onTaskDragOver(taskId: string, event: DragEvent) {
+  event.preventDefault()
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+  dragOverTaskId.value = taskId
+}
+
+function onTaskDragLeave() {
+  dragOverTaskId.value = null
+}
+
+function onTaskDrop(targetId: string, event: DragEvent) {
+  event.preventDefault()
+  const sourceId = draggingTaskId.value
+  draggingTaskId.value = null
+  dragOverTaskId.value = null
+  if (sourceId && sourceId !== targetId) {
+    moveTask(sourceId, targetId)
+  }
+}
+
+function onTaskDragEnd() {
+  draggingTaskId.value = null
+  dragOverTaskId.value = null
+}
+
+async function moveTaskUp(task: MyTask | Task, event: Event) {
+  event.stopPropagation()
+  const list = sectionTasks.value
+  const idx = list.findIndex(t => t.id === task.id)
+  if (idx <= 0) return
+  const target = list[idx - 1]
+  if (target) await moveTask(task.id, target.id)
+}
+
+async function moveTaskDown(task: MyTask | Task, event: Event) {
+  event.stopPropagation()
+  const list = sectionTasks.value
+  const idx = list.findIndex(t => t.id === task.id)
+  if (idx === -1 || idx >= list.length - 1) return
+  const target = list[idx + 1]
+  if (target) await moveTask(task.id, target.id)
+}
+
+function isTopTask(task: MyTask | Task): boolean {
+  const list = sectionTasks.value
+  return list.length > 0 && list[0]?.id === task.id
+}
+
+function isBottomTask(task: MyTask | Task): boolean {
+  const list = sectionTasks.value
+  return list.length > 0 && list[list.length - 1]?.id === task.id
+}
+
+// Multi-select for bulk actions
+const selectedTaskIds = ref<Set<string>>(new Set())
+const bulkMode = ref(false)
+const bulkPriority = ref<number | null>(null)
+const bulkDueDate = ref<string>('')
+const bulkAddTags = ref('')
+const bulkSaving = ref(false)
+
+function toggleBulkMode() {
+  bulkMode.value = !bulkMode.value
+  if (!bulkMode.value) {
+    selectedTaskIds.value.clear()
+    bulkPriority.value = null
+    bulkDueDate.value = ''
+  }
+}
+
+function toggleTaskSelection(taskId: string, event: Event) {
+  event.stopPropagation()
+  if (selectedTaskIds.value.has(taskId)) {
+    selectedTaskIds.value.delete(taskId)
+  } else {
+    selectedTaskIds.value.add(taskId)
+  }
+}
+
+function selectAllVisible() {
+  for (const t of sectionTasks.value) {
+    selectedTaskIds.value.add(t.id)
+  }
+}
+
+function clearSelection() {
+  selectedTaskIds.value.clear()
+}
+
+async function applyBulkUpdate() {
+  if (selectedTaskIds.value.size === 0) return
+  bulkSaving.value = true
+  try {
+    const patch: BulkPatchFields = {}
+    if (bulkPriority.value !== null) patch.priority = bulkPriority.value
+    if (bulkDueDate.value) patch.due_date = bulkDueDate.value
+    if (bulkAddTags.value.trim()) {
+      patch.add_tags = bulkAddTags.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean)
+    }
+    if (bulkPriority.value === null && !bulkDueDate.value && !bulkAddTags.value.trim()) {
+      toast.info('Nothing to update — set a priority, date, or tags first')
+      return
+    }
+    const ids = Array.from(selectedTaskIds.value)
+    await bulkUpdateTasks(ids, patch)
+    bulkPriority.value = null
+    bulkDueDate.value = ''
+    bulkAddTags.value = ''
+    await loadAll()
+    toast.success(`Updated ${ids.length} task${ids.length > 1 ? 's' : ''}`)
+  } catch (e) {
+    toast.error(String(e))
+  } finally {
+    bulkSaving.value = false
+  }
+}
+
+async function bulkMarkDone() {
+  if (selectedTaskIds.value.size === 0) return
+  bulkSaving.value = true
+  try {
+    const ids = Array.from(selectedTaskIds.value)
+    await bulkUpdateTasks(ids, { status: 'done' })
+    clearSelection()
+    await loadAll()
+    toast.success(`Marked ${ids.length} task${ids.length > 1 ? 's' : ''} done`)
+  } catch (e) {
+    toast.error(String(e))
+  } finally {
+    bulkSaving.value = false
+  }
+}
+
+const showBulkDeleteConfirm = ref(false)
+
+async function bulkDeleteSelected() {
+  if (selectedTaskIds.value.size === 0) return
+  bulkSaving.value = true
+  try {
+    const ids = Array.from(selectedTaskIds.value)
+    await bulkDeleteTasks(ids)
+    clearSelection()
+    showBulkDeleteConfirm.value = false
+    await loadAll()
+    toast.success(`Deleted ${ids.length} task${ids.length > 1 ? 's' : ''}`)
+  } catch (e) {
+    toast.error(String(e))
+  } finally {
+    bulkSaving.value = false
+  }
+}
+
+// Load employees and tags
+async function loadEmployees() {
+  try {
+    employees.value = await getEmployees()
+  } catch (e) {
+    toast.error(String(e))
+  }
+}
+
+async function loadAllTags() {
+  try {
+    allTags.value = await getTags()
+  } catch (e) {
+    toast.error(String(e))
+  }
 }
 
 // Deep-link: open task from URL
@@ -376,7 +718,11 @@ watch(taskModalVisible, (visible) => {
   }
 })
 
-onMounted(loadAll)
+onMounted(() => {
+  loadAll()
+  loadEmployees()
+  loadAllTags()
+})
 </script>
 
 <template>
@@ -386,7 +732,19 @@ onMounted(loadAll)
         <h1>My Tasks</h1>
         <div class="header-actions">
           <span class="task-count">{{ activeTasks.length }} active</span>
-          <button class="btn-add-task" @click="openQuickAdd">
+          <button
+            class="btn-bulk-toggle"
+            :class="{ active: bulkMode }"
+            @click="toggleBulkMode"
+          >
+            <i class="pi pi-check-square" />
+            {{ bulkMode ? 'Done' : 'Select' }}
+          </button>
+          <button class="btn-add-task btn-quick-task" @click="openQuickAdd">
+            <i class="pi pi-plus" />
+            Quick Task
+          </button>
+          <button class="btn-add-task" @click="openAddTask">
             <i class="pi pi-plus" />
             Add Task
           </button>
@@ -415,7 +773,7 @@ onMounted(loadAll)
       <div class="quick-add-row">
         <select v-model="quickAddProjectId" class="quick-add-select">
           <option value="" disabled>Select project...</option>
-          <option v-for="p in projects" :key="p.id" :value="p.id">
+          <option v-for="p in sortedProjects" :key="p.id" :value="p.id">
             {{ p.project_name }}{{ p.job_code ? ` (${p.job_code})` : '' }}
           </option>
         </select>
@@ -431,6 +789,19 @@ onMounted(loadAll)
           class="quick-add-date"
           type="date"
         />
+        <select v-model="quickAddPriority" class="quick-add-priority">
+          <option :value="null">Priority...</option>
+          <option :value="1">Low</option>
+          <option :value="2">Medium</option>
+          <option :value="3">High</option>
+        </select>
+        <input
+          v-model="quickAddTags"
+          class="quick-add-tags"
+          type="text"
+          placeholder="Tags (comma-separated)..."
+          @keydown.enter="submitQuickAdd"
+        />
         <button
           class="quick-add-submit"
           :disabled="!quickAddTitle.trim() || !quickAddProjectId || quickAddSubmitting"
@@ -442,6 +813,47 @@ onMounted(loadAll)
           <i class="pi pi-times" />
         </button>
       </div>
+    </div>
+
+    <!-- Bulk action bar -->
+    <div v-if="bulkMode && selectedTaskIds.size > 0" class="bulk-action-bar">
+      <span class="bulk-count">{{ selectedTaskIds.size }} selected</span>
+      <select v-model="bulkPriority" class="bulk-select">
+        <option :value="null">Priority...</option>
+        <option :value="1">Low</option>
+        <option :value="2">Medium</option>
+        <option :value="3">High</option>
+      </select>
+      <input v-model="bulkDueDate" type="date" class="bulk-date" />
+      <input
+        v-model="bulkAddTags"
+        type="text"
+        class="bulk-tags"
+        placeholder="Add tags (comma-separated)..."
+      />
+      <button class="btn btn-sm btn-success" :disabled="bulkSaving" @click="bulkMarkDone">
+        <i class="pi pi-check" /> Mark Done
+      </button>
+      <template v-if="!showBulkDeleteConfirm">
+        <button class="btn btn-sm btn-danger" :disabled="bulkSaving" @click="showBulkDeleteConfirm = true">
+          <i class="pi pi-trash" /> Delete
+        </button>
+      </template>
+      <template v-else>
+        <span class="bulk-confirm-text">Delete {{ selectedTaskIds.size }} task{{ selectedTaskIds.size > 1 ? 's' : '' }}?</span>
+        <button class="btn btn-sm btn-danger" :disabled="bulkSaving" @click="bulkDeleteSelected">
+          {{ bulkSaving ? 'Deleting...' : 'Yes, delete' }}
+        </button>
+        <button class="btn btn-sm" @click="showBulkDeleteConfirm = false">Cancel</button>
+      </template>
+      <span class="bulk-spacer" />
+      <button class="btn btn-sm btn-primary" :disabled="bulkSaving" @click="applyBulkUpdate">
+        {{ bulkSaving ? 'Updating...' : 'Apply' }}
+      </button>
+      <button class="btn btn-sm" @click="clearSelection">Clear</button>
+    </div>
+    <div v-else-if="bulkMode" class="bulk-action-hint">
+      Select tasks to update. <button class="link-btn" @click="selectAllVisible">Select all visible</button>
     </div>
 
     <div v-if="loading" class="loading">Loading tasks...</div>
@@ -514,7 +926,7 @@ onMounted(loadAll)
               <button v-if="selectedProjectIds.size > 0" class="link-btn" @click="clearProjectFilter">Clear</button>
             </div>
             <label
-              v-for="p in projects"
+              v-for="p in sortedProjects"
               :key="p.id"
               class="dropdown-row"
             >
@@ -527,6 +939,85 @@ onMounted(loadAll)
             </label>
             <div v-if="!projects.length" class="dropdown-empty">Loading…</div>
           </div>
+        </div>
+
+        <!-- Assignee filter -->
+        <div class="project-chip-wrap">
+          <button
+            class="chip"
+            :class="{ active: assigneeFilter !== 'me' || selectedAssigneeIds.size > 0 }"
+            @click="assigneeFilterOpen = !assigneeFilterOpen"
+          >
+            <i class="pi pi-users" style="font-size: 0.625rem; margin-right: 0.25rem" />
+            {{ assigneeFilterLabel }}
+          </button>
+          <div v-if="assigneeFilterOpen" class="project-dropdown">
+            <div class="dropdown-header">
+              <span>Filter by assignee</span>
+            </div>
+            <button class="dropdown-row dropdown-row-btn" :class="{ selected: assigneeFilter === 'me' }" @click="setAssigneeFilter('me')">
+              Just me
+            </button>
+            <button class="dropdown-row dropdown-row-btn" :class="{ selected: assigneeFilter === 'everyone' }" @click="setAssigneeFilter('everyone')">
+              Everyone
+            </button>
+            <div class="dropdown-divider" />
+            <label
+              v-for="emp in employees"
+              :key="emp.id"
+              class="dropdown-row"
+            >
+              <input
+                type="checkbox"
+                :checked="selectedAssigneeIds.has(emp.id)"
+                @change="toggleAssigneeFilter(emp.id)"
+              />
+              <span>{{ emp.first_name }} {{ emp.last_name }}</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Tag filter -->
+        <div v-if="allTags.length > 0" class="project-chip-wrap">
+          <button
+            class="chip"
+            :class="{ active: selectedTagIds.size > 0 }"
+            @click="tagFilterOpen = !tagFilterOpen"
+          >
+            <i class="pi pi-tags" style="font-size: 0.625rem; margin-right: 0.25rem" />
+            Tags
+            <span v-if="selectedTagIds.size > 0" class="chip-count">{{ selectedTagIds.size }}</span>
+          </button>
+          <div v-if="tagFilterOpen" class="project-dropdown">
+            <div class="dropdown-header">
+              <span>Filter by tag</span>
+              <button v-if="selectedTagIds.size > 0" class="link-btn" @click="clearTagFilter">Clear</button>
+            </div>
+            <label
+              v-for="tag in allTags"
+              :key="tag"
+              class="dropdown-row"
+            >
+              <input
+                type="checkbox"
+                :checked="selectedTagIds.has(tag)"
+                @change="toggleTagFilter(tag)"
+              />
+              <span class="tag-label">{{ tag }}</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Sort dropdown -->
+        <div class="project-chip-wrap sort-wrap">
+          <select v-model="sortMode" class="sort-select" @change="loadAll">
+            <option value="due_date">Sort: Due date</option>
+            <option value="priority">Sort: Priority</option>
+            <option value="project">Sort: Project</option>
+            <option value="assignee">Sort: Assignee</option>
+            <option value="tags">Sort: Tags</option>
+            <option value="manual">Sort: Manual</option>
+          </select>
         </div>
       </div>
 
@@ -544,8 +1035,32 @@ onMounted(loadAll)
             <template v-else-if="activeFilter === 'stale'">No stale tasks (untouched 30+ days).</template>
             <template v-else>Nothing in this view.</template>
           </div>
-          <div v-for="task in sectionTasks" :key="task.id" class="task-block">
+          <div
+            v-for="task in sectionTasks"
+            :key="task.id"
+            class="task-block"
+            :class="{
+              'task-pinned': task.is_pinned,
+              'dragging': draggingTaskId === task.id,
+              'drag-over': dragOverTaskId === task.id,
+              'reorderable': sortMode === 'manual',
+            }"
+            :draggable="sortMode === 'manual'"
+            @dragstart="onTaskDragStart(task.id, $event)"
+            @dragover="onTaskDragOver(task.id, $event)"
+            @dragleave="onTaskDragLeave"
+            @drop="onTaskDrop(task.id, $event)"
+            @dragend="onTaskDragEnd"
+          >
             <div class="task-row" @click="openTask(task)">
+              <button
+                v-if="bulkMode"
+                class="checkbox bulk-checkbox"
+                :class="{ checked: selectedTaskIds.has(task.id) }"
+                @click="toggleTaskSelection(task.id, $event)"
+              >
+                <i class="pi" :class="selectedTaskIds.has(task.id) ? 'pi-check' : ''" />
+              </button>
               <button
                 class="checkbox"
                 :class="{ checked: task.status === 'done' }"
@@ -554,7 +1069,36 @@ onMounted(loadAll)
               >
                 <i class="pi" :class="task.status === 'done' ? 'pi-check' : ''" />
               </button>
+              <button
+                class="pin-btn"
+                :class="{ active: task.is_pinned }"
+                title="Pin to top"
+                @click.stop="togglePin(task, $event)"
+              >
+                <i class="pi" :class="task.is_pinned ? 'pi-bookmark-fill' : 'pi-bookmark'" />
+              </button>
+              <template v-if="sortMode === 'manual'">
+                <button
+                  class="reorder-btn"
+                  :disabled="isTopTask(task)"
+                  title="Move up"
+                  @click.stop="moveTaskUp(task, $event)"
+                >
+                  <i class="pi pi-angle-up" />
+                </button>
+                <button
+                  class="reorder-btn"
+                  :disabled="isBottomTask(task)"
+                  title="Move down"
+                  @click.stop="moveTaskDown(task, $event)"
+                >
+                  <i class="pi pi-angle-down" />
+                </button>
+              </template>
               <span class="task-title" :class="{ completed: task.status === 'done' }">{{ task.title }}</span>
+              <span v-if="task.tags && task.tags.length" class="task-tags">
+                <span v-for="tag in task.tags" :key="tag" class="task-tag-chip">{{ tag }}</span>
+              </span>
               <span class="project-chip" @click.stop="router.push('/projects/' + task.project_id)">
                 {{ task.project_name }}<span v-if="task.job_code" class="job-code"> ({{ task.job_code }})</span>
               </span>
@@ -650,8 +1194,16 @@ onMounted(loadAll)
               <span class="group-count">{{ group.tasks.length }}</span>
             </div>
             <div v-if="!collapsedLaterProjects.has(projectId)" class="task-list">
-              <div v-for="task in group.tasks" :key="task.id" class="task-block">
+              <div v-for="task in group.tasks" :key="task.id" class="task-block" :class="{ 'task-pinned': task.is_pinned }">
                 <div class="task-row" @click="openTask(task)">
+                  <button
+                    v-if="bulkMode"
+                    class="checkbox bulk-checkbox"
+                    :class="{ checked: selectedTaskIds.has(task.id) }"
+                    @click="toggleTaskSelection(task.id, $event)"
+                  >
+                    <i class="pi" :class="selectedTaskIds.has(task.id) ? 'pi-check' : ''" />
+                  </button>
                   <button
                     class="checkbox"
                     :class="{ checked: task.status === 'done' }"
@@ -659,7 +1211,18 @@ onMounted(loadAll)
                   >
                     <i class="pi" :class="task.status === 'done' ? 'pi-check' : ''" />
                   </button>
+                  <button
+                    class="pin-btn"
+                    :class="{ active: task.is_pinned }"
+                    title="Pin to top"
+                    @click.stop="togglePin(task, $event)"
+                  >
+                    <i class="pi" :class="task.is_pinned ? 'pi-bookmark-fill' : 'pi-bookmark'" />
+                  </button>
                   <span class="task-title">{{ task.title }}</span>
+                  <span v-if="task.tags && task.tags.length" class="task-tags">
+                    <span v-for="tag in task.tags" :key="tag" class="task-tag-chip">{{ tag }}</span>
+                  </span>
                   <span class="spacer" />
                   <span class="row-chips">
                     <button class="btn-copy-link row-chip-icon" title="Copy link" @click.stop="copyLink(`/my-tasks/${task.id}`)">
@@ -1135,6 +1698,12 @@ onMounted(loadAll)
 }
 .btn-add-task:hover { filter: brightness(1.1); }
 .btn-add-task .pi { font-size: 0.625rem; }
+.btn-quick-task {
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  border: 1px solid var(--p-content-border-color);
+}
+.btn-quick-task:hover { background: var(--p-content-hover-background); filter: none; }
 
 /* Quick Add Form */
 .quick-add-form {
@@ -1157,6 +1726,26 @@ onMounted(loadAll)
 .quick-add-select { min-width: 160px; max-width: 200px; }
 .quick-add-input { flex: 1; }
 .quick-add-date { width: 140px; }
+.quick-add-priority {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+.quick-add-priority:focus { outline: none; border-color: var(--p-primary-color); }
+.quick-add-tags {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  font-size: 0.8125rem;
+  min-width: 160px;
+}
+.quick-add-tags:focus { outline: none; border-color: var(--p-primary-color); }
 .quick-add-input:focus, .quick-add-select:focus, .quick-add-date:focus {
   outline: none;
   border-color: var(--p-primary-color);
@@ -1231,4 +1820,156 @@ onMounted(loadAll)
   padding: 0.1875rem 0.375rem;
   opacity: 1 !important;
 }
+
+/* Pin button on task rows */
+.pin-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--p-text-muted-color);
+  padding: 0.1875rem 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0.4;
+  transition: opacity 0.15s, color 0.15s;
+}
+.pin-btn:hover { opacity: 1; color: var(--p-primary-color); }
+.pin-btn.active { opacity: 1; color: var(--p-primary-color); }
+.task-pinned {
+  background: var(--p-highlight-background);
+  border-left: 3px solid var(--p-primary-color);
+  border-radius: 0.25rem;
+}
+
+/* Tag chips on task rows */
+.task-tags {
+  display: inline-flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+.task-tag-chip {
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.375rem;
+  background: var(--p-content-hover-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 9999px;
+  color: var(--p-text-muted-color);
+  white-space: nowrap;
+}
+
+/* Sort dropdown */
+.sort-wrap { margin-left: auto; }
+.sort-select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.sort-select:focus { outline: none; border-color: var(--p-primary-color); }
+
+/* Dropdown helpers for assignee/tag filter */
+.dropdown-row-btn {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--p-text-color);
+}
+.dropdown-row-btn:hover { background: var(--p-content-hover-background); }
+.dropdown-row-btn.selected { font-weight: 600; color: var(--p-primary-color); }
+.dropdown-divider {
+  height: 1px;
+  background: var(--p-content-border-color);
+  margin: 0.25rem 0;
+}
+.tag-label { text-transform: lowercase; }
+
+/* Bulk action bar */
+.btn-bulk-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: all 0.15s;
+}
+.btn-bulk-toggle:hover { border-color: var(--p-primary-color); color: var(--p-text-color); }
+.btn-bulk-toggle.active { background: var(--p-primary-color); color: #fff; border-color: var(--p-primary-color); }
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--p-highlight-background);
+  border: 1px solid var(--p-primary-color);
+  border-radius: 0.5rem;
+}
+.bulk-count { font-size: 0.8125rem; font-weight: 600; color: var(--p-primary-color); }
+.bulk-spacer { flex: 1; }
+.bulk-select, .bulk-date, .bulk-tags {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 0.375rem;
+  background: var(--p-content-background);
+  color: var(--p-text-color);
+  font-size: 0.8125rem;
+}
+.bulk-select:focus, .bulk-date:focus, .bulk-tags:focus { outline: none; border-color: var(--p-primary-color); }
+.bulk-tags { min-width: 180px; }
+.bulk-action-hint {
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--p-content-hover-background);
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+}
+.link-btn {
+  background: none;
+  border: none;
+  color: var(--p-primary-color);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  text-decoration: underline;
+  padding: 0;
+}
+.bulk-checkbox { border-color: var(--p-primary-color); }
+.bulk-confirm-text { font-size: 0.8125rem; color: var(--p-red-600); font-weight: 600; }
+.btn-success { background: var(--p-green-600); color: #fff; border-color: var(--p-green-600); }
+.btn-success:hover { background: var(--p-green-700); }
+.btn-success:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-danger { color: var(--p-red-600); border-color: var(--p-red-300); }
+.btn-danger:hover { background: var(--p-red-50); }
+.btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Manual reordering */
+.reorder-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--p-text-muted-color);
+  padding: 0.125rem 0.1875rem;
+  font-size: 0.8125rem;
+  opacity: 0.4;
+  transition: opacity 0.15s, color 0.15s;
+}
+.reorder-btn:hover { opacity: 1; color: var(--p-primary-color); }
+.reorder-btn:disabled { opacity: 0.2; cursor: not-allowed; }
+.task-block.reorderable { cursor: grab; }
+.task-block.reorderable:active { cursor: grabbing; }
+.task-block.dragging { opacity: 0.4; }
+.task-block.drag-over { border-top: 2px solid var(--p-primary-color); }
 </style>


### PR DESCRIPTION
…ing, test-server banner

Task management:
- Add is_pinned and tags columns to project_tasks (migration 032)
- Pin toggle on task rows; pinned tasks sort to top with highlight
- Tag system: comma-separated tags at creation, tag chips on rows, tag filter dropdown
- Manual reorder: drag-and-drop + up/down buttons via PATCH /tasks/reorder
- Sort modes: due date, priority, project, assignee, tags, manual
- Assignee filter: just me / everyone / custom per-employee
- Select mode with bulk actions: mark done, delete (with confirmation), set priority/date/tags
- Quick Task (inline) vs Add Task (full modal in create mode)

Contacts:
- Contact dropdowns grouped by company via <optgroup> in ProjectDetail, ProjectModal, ProjectTeam
- Expanded new-contact form: first/last name, email, phone, affiliated company

Infrastructure:
- Test-server visual indicator (amber banner + sidebar accent) via useEnvironment composable
- Cache-Control: no-cache on SPA fallback for reliable JS bundle refresh
- FinancialView: clickable project links on invoice rows

API:
- GET /tasks/tags — distinct tags across non-deleted tasks
- PATCH /tasks/reorder — batch sort_order update
- DELETE /tasks/bulk — soft-delete tasks + subtasks
- list_my_tasks accepts assignee_ids and tags query params
- Bulk patch correctly merges add_tags on top of existing DB tags